### PR TITLE
feat: 키워드 기반 단순 검색 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/org/example/booksearchservice/book/application/dto/BookDetailResponse.java
+++ b/src/main/java/org/example/booksearchservice/book/application/dto/BookDetailResponse.java
@@ -14,7 +14,7 @@ public record BookDetailResponse(
         @JsonFormat(pattern = "yyyy-MM-dd")
         LocalDate published
 ) {
-    public static BookDetailResponse from(Book book) {
+    public static BookDetailResponse of(Book book) {
         return new BookDetailResponse(
                 book.getIsbn(),
                 book.getBasicInfo().getTitle(),

--- a/src/main/java/org/example/booksearchservice/book/application/dto/BookPageResponse.java
+++ b/src/main/java/org/example/booksearchservice/book/application/dto/BookPageResponse.java
@@ -1,0 +1,20 @@
+package org.example.booksearchservice.book.application.dto;
+
+import org.example.booksearchservice.book.domain.Book;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record BookPageResponse(
+        PageInfo pageInfo,
+        List<BookDetailResponse> books
+) {
+    public static BookPageResponse of(Page<Book> bookPage) {
+        return new BookPageResponse(
+                PageInfo.of(bookPage),
+                bookPage.getContent().stream()
+                        .map(BookDetailResponse::of)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/example/booksearchservice/book/application/dto/PageInfo.java
+++ b/src/main/java/org/example/booksearchservice/book/application/dto/PageInfo.java
@@ -1,0 +1,19 @@
+package org.example.booksearchservice.book.application.dto;
+
+import org.springframework.data.domain.Page;
+
+public record PageInfo(
+        int currentPage,
+        int pageSize,
+        int totalPages,
+        long totalElements
+) {
+    public static <T> PageInfo of(Page<T> page) {
+        return new PageInfo(
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalPages(),
+                page.getTotalElements()
+        );
+    }
+}

--- a/src/main/java/org/example/booksearchservice/book/application/port/LoadBookPort.java
+++ b/src/main/java/org/example/booksearchservice/book/application/port/LoadBookPort.java
@@ -1,9 +1,12 @@
 package org.example.booksearchservice.book.application.port;
 
 import org.example.booksearchservice.book.domain.Book;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
 public interface LoadBookPort {
     Optional<Book> loadById(Long id);
+    Page<Book> loadByKeyword(String keyword, Pageable pageable);
 }

--- a/src/main/java/org/example/booksearchservice/book/application/service/BookQueryService.java
+++ b/src/main/java/org/example/booksearchservice/book/application/service/BookQueryService.java
@@ -2,8 +2,12 @@ package org.example.booksearchservice.book.application.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.booksearchservice.book.application.dto.BookDetailResponse;
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.book.application.usecase.LoadBookDetailUseCase;
+import org.example.booksearchservice.book.application.usecase.LoadBooksByKeywordUseCase;
 import org.example.booksearchservice.book.domain.Book;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -11,9 +15,15 @@ import org.springframework.stereotype.Service;
 public class BookQueryService {
 
     private final LoadBookDetailUseCase loadBookDetailUseCase;
+    private final LoadBooksByKeywordUseCase loadBooksByKeywordUseCase;
 
     public BookDetailResponse getBookDetail(Long id) {
         Book book = loadBookDetailUseCase.execute(id);
-        return BookDetailResponse.from(book);
+        return BookDetailResponse.of(book);
+    }
+
+    public BookPageResponse findBooksByKeyword(String keyword, Pageable pageable) {
+        Page<Book> bookPage = loadBooksByKeywordUseCase.execute(keyword, pageable);
+        return BookPageResponse.of(bookPage);
     }
 }

--- a/src/main/java/org/example/booksearchservice/book/application/usecase/LoadBooksByKeywordUseCase.java
+++ b/src/main/java/org/example/booksearchservice/book/application/usecase/LoadBooksByKeywordUseCase.java
@@ -1,0 +1,25 @@
+package org.example.booksearchservice.book.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.booksearchservice.book.application.port.LoadBookPort;
+import org.example.booksearchservice.book.domain.Book;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LoadBooksByKeywordUseCase {
+
+    private final LoadBookPort loadBookPort;
+
+    @Transactional(readOnly = true)
+    public Page<Book> execute(String keyword, Pageable pageable) {
+        log.info("Loading books with keyword: [{}], page: [{}], size: [{}]",
+                keyword, pageable.getPageNumber(), pageable.getPageSize());
+        return loadBookPort.loadByKeyword(keyword, pageable);
+    }
+}

--- a/src/main/java/org/example/booksearchservice/book/infrastructure/persistence/BookJpaRepository.java
+++ b/src/main/java/org/example/booksearchservice/book/infrastructure/persistence/BookJpaRepository.java
@@ -1,6 +1,17 @@
 package org.example.booksearchservice.book.infrastructure.persistence;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BookJpaRepository extends JpaRepository<BookEntity, Long> {
+
+    @Query("""
+        SELECT b
+        FROM BookEntity b
+        WHERE LOWER(b.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
+           OR LOWER(b.subtitle) LIKE LOWER(CONCAT('%', :keyword, '%'))
+        """)
+    Page<BookEntity> findByKeyword(String keyword, Pageable pageable);
 }

--- a/src/main/java/org/example/booksearchservice/book/infrastructure/persistence/LoadBookAdapter.java
+++ b/src/main/java/org/example/booksearchservice/book/infrastructure/persistence/LoadBookAdapter.java
@@ -3,6 +3,8 @@ package org.example.booksearchservice.book.infrastructure.persistence;
 import lombok.RequiredArgsConstructor;
 import org.example.booksearchservice.book.application.port.LoadBookPort;
 import org.example.booksearchservice.book.domain.Book;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -16,6 +18,12 @@ public class LoadBookAdapter implements LoadBookPort {
     @Override
     public Optional<Book> loadById(Long id) {
         return bookJpaRepository.findById(id)
+                .map(BookEntity::toDomain);
+    }
+
+    @Override
+    public Page<Book> loadByKeyword(String keyword, Pageable pageable) {
+        return bookJpaRepository.findByKeyword(keyword, pageable)
                 .map(BookEntity::toDomain);
     }
 }

--- a/src/main/java/org/example/booksearchservice/search/application/aop/SearchExecutionTimeAspect.java
+++ b/src/main/java/org/example/booksearchservice/search/application/aop/SearchExecutionTimeAspect.java
@@ -1,0 +1,38 @@
+package org.example.booksearchservice.search.application.aop;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.example.booksearchservice.search.application.dto.SearchMetaData;
+import org.example.booksearchservice.search.application.dto.SearchResponse;
+import org.springframework.stereotype.Component;
+
+import static java.lang.System.currentTimeMillis;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class SearchExecutionTimeAspect {
+
+    @Around("execution(* org.example.booksearchservice.search.application.service.SearchService.*(..))")
+    public Object recordExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        long start = currentTimeMillis();
+        Object result = joinPoint.proceed();
+        long executionTime = currentTimeMillis() - start;
+
+        if (result instanceof SearchResponse response) {
+            return SearchResponse.of(
+                response.searchQuery(),
+                response.pageInfo(),
+                response.books(),
+                SearchMetaData.of(
+                    executionTime,
+                    response.searchMetaData().strategy()
+                )
+            );
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/application/dto/SearchMetaData.java
+++ b/src/main/java/org/example/booksearchservice/search/application/dto/SearchMetaData.java
@@ -1,0 +1,19 @@
+package org.example.booksearchservice.search.application.dto;
+
+import org.example.booksearchservice.search.domain.SearchOperator;
+
+public record SearchMetaData(
+        Long executionTime,
+        SearchOperator strategy
+) {
+    public static SearchMetaData ofDefaultExecutionTime(SearchOperator strategy) {
+        return new SearchMetaData(0L, strategy);
+    }
+
+    public static SearchMetaData of(Long executionTime, SearchOperator searchOperator) {
+        return new SearchMetaData(
+                executionTime,
+                searchOperator
+        );
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/application/dto/SearchResponse.java
+++ b/src/main/java/org/example/booksearchservice/search/application/dto/SearchResponse.java
@@ -1,0 +1,27 @@
+package org.example.booksearchservice.search.application.dto;
+
+import org.example.booksearchservice.book.application.dto.BookDetailResponse;
+import org.example.booksearchservice.book.application.dto.PageInfo;
+
+import java.util.List;
+
+public record SearchResponse(
+        String searchQuery,
+        PageInfo pageInfo,
+        List<BookDetailResponse> books,
+        SearchMetaData searchMetaData
+) {
+    public static SearchResponse of(
+            String searchQuery,
+            PageInfo pageInfo,
+            List<BookDetailResponse> books,
+            SearchMetaData searchMetaData
+    ) {
+        return new SearchResponse(
+                searchQuery,
+                pageInfo,
+                books,
+                searchMetaData
+        );
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/application/port/BookInternalPort.java
+++ b/src/main/java/org/example/booksearchservice/search/application/port/BookInternalPort.java
@@ -1,0 +1,8 @@
+package org.example.booksearchservice.search.application.port;
+
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface BookInternalPort {
+    BookPageResponse findBooksByKeyword(String keyword, Pageable pageable);
+}

--- a/src/main/java/org/example/booksearchservice/search/application/service/SearchService.java
+++ b/src/main/java/org/example/booksearchservice/search/application/service/SearchService.java
@@ -1,0 +1,28 @@
+package org.example.booksearchservice.search.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.example.booksearchservice.search.application.dto.SearchMetaData;
+import org.example.booksearchservice.search.application.dto.SearchResponse;
+import org.example.booksearchservice.search.application.usecase.KeywordSearchUseCase;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import static org.example.booksearchservice.search.domain.SearchOperator.NONE;
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+
+    private final KeywordSearchUseCase keywordSearchUseCase;
+
+    public SearchResponse searchBooksByKeyword(String keyword, Pageable pageable) {
+        BookPageResponse bookPageResponse = keywordSearchUseCase.execute(keyword, pageable);
+        return SearchResponse.of(
+                keyword,
+                bookPageResponse.pageInfo(),
+                bookPageResponse.books(),
+                SearchMetaData.ofDefaultExecutionTime(NONE)
+        );
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/application/usecase/KeywordSearchUseCase.java
+++ b/src/main/java/org/example/booksearchservice/search/application/usecase/KeywordSearchUseCase.java
@@ -1,0 +1,23 @@
+package org.example.booksearchservice.search.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.example.booksearchservice.search.application.port.BookInternalPort;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KeywordSearchUseCase {
+
+    private final BookInternalPort bookInternalPort;
+
+    @Transactional(readOnly = true)
+    public BookPageResponse execute(String keyword, Pageable pageable) {
+        log.info("Executing keyword search for keyword: [{}]", keyword);
+        return bookInternalPort.findBooksByKeyword(keyword, pageable);
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/domain/SearchOperator.java
+++ b/src/main/java/org/example/booksearchservice/search/domain/SearchOperator.java
@@ -1,0 +1,15 @@
+package org.example.booksearchservice.search.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SearchOperator {
+    NONE("", ""),
+    OR("|", "\\|"),
+    NOT("-", "-");
+
+    private final String querySymbol;
+    private final String splitRegex;
+}

--- a/src/main/java/org/example/booksearchservice/search/infrastructure/internal/BookInternalAdapter.java
+++ b/src/main/java/org/example/booksearchservice/search/infrastructure/internal/BookInternalAdapter.java
@@ -1,0 +1,20 @@
+package org.example.booksearchservice.search.infrastructure.internal;
+
+import lombok.RequiredArgsConstructor;
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.example.booksearchservice.book.application.service.BookQueryService;
+import org.example.booksearchservice.search.application.port.BookInternalPort;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BookInternalAdapter implements BookInternalPort {
+
+    private final BookQueryService bookQueryService;
+
+    @Override
+    public BookPageResponse findBooksByKeyword(String keyword, Pageable pageable) {
+        return bookQueryService.findBooksByKeyword(keyword, pageable);
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/presentation/dto/KeywordSearchRequest.java
+++ b/src/main/java/org/example/booksearchservice/search/presentation/dto/KeywordSearchRequest.java
@@ -1,0 +1,9 @@
+package org.example.booksearchservice.search.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record KeywordSearchRequest(
+        @NotBlank(message = "검색어 입력은 필수입니다.")
+        String keyword
+) {
+}

--- a/src/main/java/org/example/booksearchservice/search/presentation/web/SearchController.java
+++ b/src/main/java/org/example/booksearchservice/search/presentation/web/SearchController.java
@@ -1,0 +1,33 @@
+package org.example.booksearchservice.search.presentation.web;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.booksearchservice.search.application.dto.SearchResponse;
+import org.example.booksearchservice.search.application.service.SearchService;
+import org.example.booksearchservice.search.presentation.dto.KeywordSearchRequest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/search/books")
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final SearchService searchService;
+
+    private static final String  DEFAULT_PAGE = "0";
+    private static final String DEFAULT_SIZE = "20";
+
+    @GetMapping
+    public ResponseEntity<SearchResponse> searchBooks(
+            @Valid @ModelAttribute KeywordSearchRequest request,
+            @RequestParam(defaultValue = DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = DEFAULT_SIZE) int size) {
+
+        Pageable pageable = PageRequest.of(page, size);
+        SearchResponse response = searchService.searchBooksByKeyword(request.keyword(), pageable);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/test/java/org/example/booksearchservice/book/application/service/BookQueryServiceTest.java
+++ b/src/test/java/org/example/booksearchservice/book/application/service/BookQueryServiceTest.java
@@ -1,33 +1,40 @@
 package org.example.booksearchservice.book.application.service;
 
 import org.example.booksearchservice.book.application.dto.BookDetailResponse;
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.book.application.usecase.LoadBookDetailUseCase;
-import org.example.booksearchservice.book.domain.BasicInfo;
+import org.example.booksearchservice.book.application.usecase.LoadBooksByKeywordUseCase;
 import org.example.booksearchservice.book.domain.Book;
-import org.example.booksearchservice.book.domain.PublicationInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
-import java.time.LocalDate;
+import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.example.booksearchservice.fixture.BookFixture.createBook;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class BookQueryServiceTest {
 
     private LoadBookDetailUseCase loadBookUseCase;
+    private LoadBooksByKeywordUseCase loadBooksByKeywordUseCase;
     private BookQueryService bookQueryService;
 
     @BeforeEach
     void setUp() {
         loadBookUseCase = mock(LoadBookDetailUseCase.class);
-        bookQueryService = new BookQueryService(loadBookUseCase);
+        loadBooksByKeywordUseCase = mock(LoadBooksByKeywordUseCase.class);
+        bookQueryService = new BookQueryService(loadBookUseCase, loadBooksByKeywordUseCase);
     }
 
     @Test
-    @DisplayName("[SUCCESS] 유효한 책 ID로 조회하면 BookDetailResponse를 반환한다")
+    @DisplayName("[SUCCESS] 책 ID로 책 상세 정보를 조회하면 책 상세 응답을 반환한다")
     void getBookDetail_givenExistingBookId_returnsBookDetailResponse() {
         // given
         Long bookId = 1L;
@@ -41,22 +48,23 @@ class BookQueryServiceTest {
         assertThat(response.isbn()).isEqualTo(book.getIsbn());
     }
 
-    private Book createBook() {
-        BasicInfo basicInfo = BasicInfo.builder()
-                .title("Effective Java")
-                .subtitle("Programming Language Guide")
-                .author("Joshua Bloch")
-                .build();
 
-        PublicationInfo pubInfo = PublicationInfo.builder()
-                .publisher("Addison-Wesley")
-                .publishedDate(LocalDate.of(2018, 1, 11))
-                .build();
+    @Test
+    @DisplayName("[SUCCESS] 키워드와 페이징 정보를 이용해 책 목록을 조회하면 페이지 응답을 반환한다")
+    void findBooksByKeyword_givenKeywordAndPageable_returnsBookPageResponse() {
+        // given
+        String keyword = "java";
+        Pageable pageable = PageRequest.of(0, 10);
 
-        return Book.builder()
-                .isbn("978-3-16-148410-0")
-                .basicInfo(basicInfo)
-                .publicationInfo(pubInfo)
-                .build();
+        List<Book> books = List.of(createBook());
+        Page<Book> bookPage = new PageImpl<>(books, pageable, books.size());
+
+        when(loadBooksByKeywordUseCase.execute(keyword, pageable)).thenReturn(bookPage);
+
+        // when
+        BookPageResponse response = bookQueryService.findBooksByKeyword(keyword, pageable);
+
+        // then
+        assertThat(response.books().getFirst().isbn()).isEqualTo(books.getFirst().getIsbn());
     }
 }

--- a/src/test/java/org/example/booksearchservice/book/application/usecase/LoadBooksByKeywordUseCaseTest.java
+++ b/src/test/java/org/example/booksearchservice/book/application/usecase/LoadBooksByKeywordUseCaseTest.java
@@ -1,0 +1,40 @@
+package org.example.booksearchservice.book.application.usecase;
+
+import org.example.booksearchservice.book.domain.Book;
+import org.example.booksearchservice.mock.FakeLoadBookAdapter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+class LoadBooksByKeywordUseCaseTest {
+
+    private LoadBooksByKeywordUseCase loadBooksByKeywordUseCase;
+
+    @BeforeEach
+    void setUp() {
+        FakeLoadBookAdapter fakeLoadBookAdapter = new FakeLoadBookAdapter();
+        loadBooksByKeywordUseCase = new LoadBooksByKeywordUseCase(fakeLoadBookAdapter);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 키워드와 페이징으로 도서 목록을 조회할 수 있다")
+    void execute_givenKeywordAndPageable_returnsBooks() {
+        // given
+        String keyword = "java";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<Book> bookPage = loadBooksByKeywordUseCase.execute(keyword, pageable);
+
+        // then
+        assertThat(bookPage.getContent()).isNotNull();
+        assertThat(bookPage.getNumber()).isEqualTo(pageable.getPageNumber());
+        assertThat(bookPage.getSize()).isEqualTo(pageable.getPageSize());
+    }
+}
+

--- a/src/test/java/org/example/booksearchservice/book/presentation/BookControllerTest.java
+++ b/src/test/java/org/example/booksearchservice/book/presentation/BookControllerTest.java
@@ -1,8 +1,5 @@
 package org.example.booksearchservice.book.presentation;
 
-import org.example.booksearchservice.book.domain.BasicInfo;
-import org.example.booksearchservice.book.domain.Book;
-import org.example.booksearchservice.book.domain.PublicationInfo;
 import org.example.booksearchservice.book.infrastructure.persistence.BookEntity;
 import org.example.booksearchservice.book.infrastructure.persistence.BookJpaRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,8 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.time.LocalDate;
-
+import static org.example.booksearchservice.fixture.BookFixture.createBook;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -35,13 +31,14 @@ class BookControllerTest {
 
     @BeforeEach
     void setup() {
+        bookJpaRepository.deleteAll();
         BookEntity bookEntity = BookEntity.fromDomain(createBook());
         savedBookEntity = bookJpaRepository.save(bookEntity);
     }
 
     @Test
-    @DisplayName("[SUCCESS] 책 상세 조회 API 호출 시 DB와 연동하여 응답 반환")
-    void getBookDetail_Success() throws Exception {
+    @DisplayName("[SUCCESS] 도서 상세 조회 시, 200 OK 및 조회 결과를 반환한다")
+    void getBookDetail_success() throws Exception {
         mockMvc.perform(get("/api/books/" + savedBookEntity.getId())
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -51,24 +48,5 @@ class BookControllerTest {
                 .andExpect(jsonPath("$.author").value("Joshua Bloch"))
                 .andExpect(jsonPath("$.publisher").value("Addison-Wesley"))
                 .andExpect(jsonPath("$.published").value("2018-01-11"));
-    }
-
-    private Book createBook() {
-        BasicInfo basicInfo = BasicInfo.builder()
-                .title("Effective Java")
-                .subtitle("Programming Language Guide")
-                .author("Joshua Bloch")
-                .build();
-
-        PublicationInfo pubInfo = PublicationInfo.builder()
-                .publisher("Addison-Wesley")
-                .publishedDate(LocalDate.of(2018, 1, 11))
-                .build();
-
-        return Book.builder()
-                .isbn("978-3-16-148410-0")
-                .basicInfo(basicInfo)
-                .publicationInfo(pubInfo)
-                .build();
     }
 }

--- a/src/test/java/org/example/booksearchservice/fixture/BookFixture.java
+++ b/src/test/java/org/example/booksearchservice/fixture/BookFixture.java
@@ -1,0 +1,25 @@
+package org.example.booksearchservice.fixture;
+
+import org.example.booksearchservice.book.domain.BasicInfo;
+import org.example.booksearchservice.book.domain.Book;
+import org.example.booksearchservice.book.domain.PublicationInfo;
+
+import java.time.LocalDate;
+
+public class BookFixture {
+
+    public static Book createBook() {
+        return Book.builder()
+                .isbn("978-3-16-148410-0")
+                .basicInfo(BasicInfo.builder()
+                        .title("Effective Java")
+                        .subtitle("Programming Language Guide")
+                        .author("Joshua Bloch")
+                        .build())
+                .publicationInfo(PublicationInfo.builder()
+                        .publisher("Addison-Wesley")
+                        .publishedDate(LocalDate.of(2018, 1, 11))
+                        .build())
+                .build();
+    }
+}

--- a/src/test/java/org/example/booksearchservice/mock/FakeBookInternalAdapter.java
+++ b/src/test/java/org/example/booksearchservice/mock/FakeBookInternalAdapter.java
@@ -1,0 +1,22 @@
+package org.example.booksearchservice.mock;
+
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.example.booksearchservice.book.domain.Book;
+import org.example.booksearchservice.search.application.port.BookInternalPort;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static org.example.booksearchservice.fixture.BookFixture.createBook;
+
+public class FakeBookInternalAdapter implements BookInternalPort {
+
+    @Override
+    public BookPageResponse findBooksByKeyword(String keyword, Pageable pageable) {
+        List<Book> books = List.of(createBook());
+        Page<Book> bookPage = new PageImpl<>(books, pageable, books.size());
+        return BookPageResponse.of(bookPage);
+    }
+}

--- a/src/test/java/org/example/booksearchservice/mock/FakeLoadBookAdapter.java
+++ b/src/test/java/org/example/booksearchservice/mock/FakeLoadBookAdapter.java
@@ -4,11 +4,18 @@ import org.example.booksearchservice.book.application.port.LoadBookPort;
 import org.example.booksearchservice.book.domain.BasicInfo;
 import org.example.booksearchservice.book.domain.Book;
 import org.example.booksearchservice.book.domain.PublicationInfo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
 
 public class FakeLoadBookAdapter implements LoadBookPort {
 
@@ -44,5 +51,23 @@ public class FakeLoadBookAdapter implements LoadBookPort {
     @Override
     public Optional<Book> loadById(Long id) {
         return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Page<Book> loadByKeyword(String keyword, Pageable pageable) {
+        List<Book> filteredBooks = store.values().stream()
+                .filter(book -> book.getBasicInfo()
+                        .getTitle()
+                        .toLowerCase()
+                        .contains(keyword.toLowerCase()))
+                .toList();
+
+        int pageOffset = toIntExact(pageable.getOffset());
+        int pageLimit = min((pageOffset + pageable.getPageSize()), filteredBooks.size());
+        List<Book> pagedBooks = (pageOffset <= pageLimit)
+                ? filteredBooks.subList(pageOffset, pageLimit)
+                : List.of();
+
+        return new PageImpl<>(pagedBooks, pageable, filteredBooks.size());
     }
 }

--- a/src/test/java/org/example/booksearchservice/search/presentation/SearchControllerTest.java
+++ b/src/test/java/org/example/booksearchservice/search/presentation/SearchControllerTest.java
@@ -1,0 +1,68 @@
+package org.example.booksearchservice.search.presentation;
+
+import org.example.booksearchservice.book.infrastructure.persistence.BookEntity;
+import org.example.booksearchservice.book.infrastructure.persistence.BookJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.example.booksearchservice.fixture.BookFixture.createBook;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@AutoConfigureMockMvc
+public class SearchControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private BookJpaRepository bookJpaRepository;
+
+    private BookEntity savedBookEntity;
+
+    @BeforeEach
+    void setup() {
+        bookJpaRepository.deleteAll();
+        BookEntity bookEntity = BookEntity.fromDomain(createBook());
+        savedBookEntity = bookJpaRepository.save(bookEntity);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 키워드로 책을 검색하면, 200 OK 및 검색 결과를 반환한다")
+    void searchBooks_success() throws Exception {
+        // given
+        String keyword = savedBookEntity.getTitle();
+
+        // when & then
+        mockMvc.perform(get("/api/search/books")
+                        .param("keyword", keyword)
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.searchQuery").value(keyword))
+                .andExpect(jsonPath("$.pageInfo.totalElements").value(1))
+                .andExpect(jsonPath("$.books[0].isbn").value(savedBookEntity.getIsbn()))
+                .andExpect(jsonPath("$.searchMetaData.strategy").value("NONE"))
+                .andExpect(jsonPath("$.searchMetaData.executionTime").isNumber());
+    }
+
+    @Test
+    @DisplayName("[FAILURE] 키워드가 누락된 경우, 400 Bad Request를 반환한다")
+    void searchBooks_keywordMissing_badRequest() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/search/books")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/org/example/booksearchservice/search/service/SearchServiceTest.java
+++ b/src/test/java/org/example/booksearchservice/search/service/SearchServiceTest.java
@@ -1,0 +1,62 @@
+package org.example.booksearchservice.search.service;
+
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.example.booksearchservice.book.domain.Book;
+import org.example.booksearchservice.search.application.dto.SearchResponse;
+import org.example.booksearchservice.search.application.service.SearchService;
+import org.example.booksearchservice.search.application.usecase.KeywordSearchUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.example.booksearchservice.fixture.BookFixture.createBook;
+import static org.example.booksearchservice.search.domain.SearchOperator.NONE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SearchServiceTest {
+
+    private KeywordSearchUseCase keywordSearchUseCase;
+    private SearchService searchService;
+
+    @BeforeEach
+    void setUp() {
+        keywordSearchUseCase = mock(KeywordSearchUseCase.class);
+        searchService = new SearchService(keywordSearchUseCase);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 키워드로 책을 검색하면 메타데이터가 포함된 검색 결과를 반환한다")
+    void searchBooksByKeyword_returnsSearchResponse() {
+        // given
+        String keyword = "java";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        List<Book> books = List.of(createBook());
+        Page<Book> bookPage = new PageImpl<>(books, pageable, books.size());
+        BookPageResponse bookPageResponse = BookPageResponse.of(bookPage);
+
+        when(keywordSearchUseCase.execute(keyword, pageable)).thenReturn(bookPageResponse);
+
+        // when
+        SearchResponse response = searchService.searchBooksByKeyword(keyword, pageable);
+
+        // then
+        AssertionsForClassTypes.assertThat(
+                response.books().stream()
+                        .anyMatch(book ->
+                                book.title().toLowerCase().contains(keyword) ||
+                                        book.subtitle().toLowerCase().contains(keyword))
+        ).isTrue();
+        assertThat(response.searchMetaData().strategy()).isEqualTo(NONE);
+        assertThat(response.searchQuery()).isEqualTo(keyword);
+    }
+}

--- a/src/test/java/org/example/booksearchservice/search/usecase/KeywordSearchUseCaseTest.java
+++ b/src/test/java/org/example/booksearchservice/search/usecase/KeywordSearchUseCaseTest.java
@@ -1,0 +1,43 @@
+package org.example.booksearchservice.search.usecase;
+
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.example.booksearchservice.mock.FakeBookInternalAdapter;
+import org.example.booksearchservice.search.application.port.BookInternalPort;
+import org.example.booksearchservice.search.application.usecase.KeywordSearchUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+public class KeywordSearchUseCaseTest {
+
+    private KeywordSearchUseCase keywordSearchUseCase;
+
+    @BeforeEach
+    void setUp() {
+        BookInternalPort bookInternalPort = new FakeBookInternalAdapter();
+        keywordSearchUseCase = new KeywordSearchUseCase(bookInternalPort);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 키워드로 책을 검색하면 페이징된 책 목록을 반환한다")
+    void execute_givenValidKeyword_returnsBookPageResponse() {
+        // given
+        String keyword = "java";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        BookPageResponse response = keywordSearchUseCase.execute(keyword, pageable);
+
+        // then
+        assertThat(
+                response.books().stream()
+                        .anyMatch(book ->
+                                book.title().toLowerCase().contains(keyword) ||
+                                book.subtitle().toLowerCase().contains(keyword))
+        ).isTrue();
+    }
+}


### PR DESCRIPTION
## 개요

단순 키워드 기반 도서 검색 기능을 도입하였습니다. 검색 API는 페이지네이션을 지원하며, 검색 결과에 메타데이터(예: 실행 시간, 검색 전략 등)를 포함합니다. 

## 주요 변경사항

#### 기능 구현

* 96a8151e71060b0cc1c497cda7c739872776820a: `GET /api/search/books` 단순 검색 API 구현 (`SearchController`)
* KeywordSearchRequest: 키워드 검색 요청 DTO (`KeywordSearchRequest`) 및 응답 DTO (`SearchResponse`, `SearchMetaData`, `PageInfo`) 추가
* 47a253db55d7d586d7e1b988dd571ed8f010a832: 검색 메타데이터 관리용 도메인 (`SearchOperator`, `SearchMetaData`) 정의
* 47a253db55d7d586d7e1b988dd571ed8f010a832: AOP 기반 실행 시간 측정 기능 (`SearchExecutionTimeAspect`) 추가

#### 도서 도메인 연동

* 3e83063206e6bfbfcccf1bf6ece0833931a8f973: `BookQueryService`에 `findBooksByKeyword` 메서드 추가
* 3e83063206e6bfbfcccf1bf6ece0833931a8f973: `LoadBookPort` 및 `LoadBookAdapter`에 키워드 기반 도서 조회 기능 (`loadByKeyword`) 추가
* fa837b24b6549520da8f75aaa68b3259e96bc05c: `BookJpaRepository`에 `@Query` 기반 검색 쿼리 추가 (제목 및 부제목 검색)

#### 내부 인터페이스 분리

* ea658ab8de7002370c645e305d0c80e4452698e9: 검색 도메인에서 도서 도메인 접근을 위한 내부 어댑터 (`BookInternalAdapter`) 및 포트 (`BookInternalPort`) 정의

## 테스트 체크리스트

* [x] 유효한 키워드 검색 시, 도서 목록과 페이지 정보 정상 반환
* [x] 키워드 누락 시 400 Bad Request 발생 및 메시지 검증
* [x] 실행 시간 메타데이터가 응답에 포함됨을 확인
* [x] 도메인 및 유스케이스 단위 테스트 통과
* [x] 컨트롤러 통합 테스트 수행 및 정상 동작 확인
* [x] 기존 `BookController` 테스트 코드 Fixture 기반으로 리팩토링

## 테스트 결과 요약

* 모든 단위 및 통합 테스트가 성공적으로 통과하였습니다.
* `GET /api/search/books?keyword=...` API 호출 시, 검색어에 해당하는 도서 목록을 페이징 형식으로 정상 반환합니다.
* 실행 시간 및 검색 전략(`SearchOperator`) 정보가 `searchMetaData` 필드에 포함됨을 확인하였습니다.
* 검색어 누락 시, `@Valid` 제약조건에 따라 400 오류가 발생하며, 적절한 메시지를 반환합니다.
