### PR TITLE
feat: 복합 검색에 OR 연산자(|) 기반 키워드 포함 검색 기능 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/org/example/booksearchservice/book/application/dto/BookDetailResponse.java
+++ b/src/main/java/org/example/booksearchservice/book/application/dto/BookDetailResponse.java
@@ -14,7 +14,7 @@ public record BookDetailResponse(
         @JsonFormat(pattern = "yyyy-MM-dd")
         LocalDate published
 ) {
-    public static BookDetailResponse from(Book book) {
+    public static BookDetailResponse of(Book book) {
         return new BookDetailResponse(
                 book.getIsbn(),
                 book.getBasicInfo().getTitle(),

--- a/src/main/java/org/example/booksearchservice/book/application/dto/BookPageResponse.java
+++ b/src/main/java/org/example/booksearchservice/book/application/dto/BookPageResponse.java
@@ -1,0 +1,20 @@
+package org.example.booksearchservice.book.application.dto;
+
+import org.example.booksearchservice.book.domain.Book;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record BookPageResponse(
+        PageInfo pageInfo,
+        List<BookDetailResponse> books
+) {
+    public static BookPageResponse of(Page<Book> bookPage) {
+        return new BookPageResponse(
+                PageInfo.of(bookPage),
+                bookPage.getContent().stream()
+                        .map(BookDetailResponse::of)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/example/booksearchservice/book/application/dto/PageInfo.java
+++ b/src/main/java/org/example/booksearchservice/book/application/dto/PageInfo.java
@@ -1,0 +1,19 @@
+package org.example.booksearchservice.book.application.dto;
+
+import org.springframework.data.domain.Page;
+
+public record PageInfo(
+        int currentPage,
+        int pageSize,
+        int totalPages,
+        long totalElements
+) {
+    public static <T> PageInfo of(Page<T> page) {
+        return new PageInfo(
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalPages(),
+                page.getTotalElements()
+        );
+    }
+}

--- a/src/main/java/org/example/booksearchservice/book/application/port/LoadBookPort.java
+++ b/src/main/java/org/example/booksearchservice/book/application/port/LoadBookPort.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface LoadBookPort {
     Optional<Book> loadById(Long id);
     Page<Book> loadByKeyword(String keyword, Pageable pageable);
+    Page<Book> loadByAnyKeywords(String firstKeyword, String secondKeyword, Pageable pageable);
 }

--- a/src/main/java/org/example/booksearchservice/book/application/port/LoadBookPort.java
+++ b/src/main/java/org/example/booksearchservice/book/application/port/LoadBookPort.java
@@ -1,9 +1,12 @@
 package org.example.booksearchservice.book.application.port;
 
 import org.example.booksearchservice.book.domain.Book;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
 public interface LoadBookPort {
     Optional<Book> loadById(Long id);
+    Page<Book> loadByKeyword(String keyword, Pageable pageable);
 }

--- a/src/main/java/org/example/booksearchservice/book/application/service/BookQueryService.java
+++ b/src/main/java/org/example/booksearchservice/book/application/service/BookQueryService.java
@@ -2,8 +2,12 @@ package org.example.booksearchservice.book.application.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.booksearchservice.book.application.dto.BookDetailResponse;
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.book.application.usecase.LoadBookDetailUseCase;
+import org.example.booksearchservice.book.application.usecase.LoadBooksByKeywordUseCase;
 import org.example.booksearchservice.book.domain.Book;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -11,9 +15,15 @@ import org.springframework.stereotype.Service;
 public class BookQueryService {
 
     private final LoadBookDetailUseCase loadBookDetailUseCase;
+    private final LoadBooksByKeywordUseCase loadBooksByKeywordUseCase;
 
     public BookDetailResponse getBookDetail(Long id) {
         Book book = loadBookDetailUseCase.execute(id);
-        return BookDetailResponse.from(book);
+        return BookDetailResponse.of(book);
+    }
+
+    public BookPageResponse findBooksByKeyword(String keyword, Pageable pageable) {
+        Page<Book> bookPage = loadBooksByKeywordUseCase.execute(keyword, pageable);
+        return BookPageResponse.of(bookPage);
     }
 }

--- a/src/main/java/org/example/booksearchservice/book/application/service/BookQueryService.java
+++ b/src/main/java/org/example/booksearchservice/book/application/service/BookQueryService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.booksearchservice.book.application.dto.BookDetailResponse;
 import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.book.application.usecase.LoadBookDetailUseCase;
+import org.example.booksearchservice.book.application.usecase.LoadBooksByAnyKeywordUseCase;
 import org.example.booksearchservice.book.application.usecase.LoadBooksByKeywordUseCase;
 import org.example.booksearchservice.book.domain.Book;
 import org.springframework.data.domain.Page;
@@ -16,6 +17,7 @@ public class BookQueryService {
 
     private final LoadBookDetailUseCase loadBookDetailUseCase;
     private final LoadBooksByKeywordUseCase loadBooksByKeywordUseCase;
+    private final LoadBooksByAnyKeywordUseCase loadBooksByAnyKeywordUseCase;
 
     public BookDetailResponse getBookDetail(Long id) {
         Book book = loadBookDetailUseCase.execute(id);
@@ -24,6 +26,11 @@ public class BookQueryService {
 
     public BookPageResponse findBooksByKeyword(String keyword, Pageable pageable) {
         Page<Book> bookPage = loadBooksByKeywordUseCase.execute(keyword, pageable);
+        return BookPageResponse.of(bookPage);
+    }
+
+    public BookPageResponse findBooksByAnyKeyword(String firstKeyword, String secondKeyword, Pageable pageable) {
+        Page<Book> bookPage = loadBooksByAnyKeywordUseCase.execute(firstKeyword, secondKeyword, pageable);
         return BookPageResponse.of(bookPage);
     }
 }

--- a/src/main/java/org/example/booksearchservice/book/application/usecase/LoadBooksByAnyKeywordUseCase.java
+++ b/src/main/java/org/example/booksearchservice/book/application/usecase/LoadBooksByAnyKeywordUseCase.java
@@ -1,0 +1,23 @@
+package org.example.booksearchservice.book.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.booksearchservice.book.application.port.LoadBookPort;
+import org.example.booksearchservice.book.domain.Book;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LoadBooksByAnyKeywordUseCase {
+
+    private final LoadBookPort loadBookPort;
+
+    public Page<Book> execute(String firstKeyword, String secondKeyword, Pageable pageable) {
+        log.info("Loading books with firstKeyword: [{}] secondKeyword [{}], page: [{}], size: [{}]",
+                firstKeyword, secondKeyword, pageable.getPageNumber(), pageable.getPageSize());
+        return loadBookPort.loadByAnyKeywords(firstKeyword, secondKeyword, pageable);
+    }
+}

--- a/src/main/java/org/example/booksearchservice/book/application/usecase/LoadBooksByKeywordUseCase.java
+++ b/src/main/java/org/example/booksearchservice/book/application/usecase/LoadBooksByKeywordUseCase.java
@@ -1,0 +1,25 @@
+package org.example.booksearchservice.book.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.booksearchservice.book.application.port.LoadBookPort;
+import org.example.booksearchservice.book.domain.Book;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LoadBooksByKeywordUseCase {
+
+    private final LoadBookPort loadBookPort;
+
+    @Transactional(readOnly = true)
+    public Page<Book> execute(String keyword, Pageable pageable) {
+        log.info("Loading books with keyword: [{}], page: [{}], size: [{}]",
+                keyword, pageable.getPageNumber(), pageable.getPageSize());
+        return loadBookPort.loadByKeyword(keyword, pageable);
+    }
+}

--- a/src/main/java/org/example/booksearchservice/book/infrastructure/persistence/BookJpaRepository.java
+++ b/src/main/java/org/example/booksearchservice/book/infrastructure/persistence/BookJpaRepository.java
@@ -1,6 +1,17 @@
 package org.example.booksearchservice.book.infrastructure.persistence;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BookJpaRepository extends JpaRepository<BookEntity, Long> {
+
+    @Query("""
+        SELECT b
+        FROM BookEntity b
+        WHERE LOWER(b.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
+           OR LOWER(b.subtitle) LIKE LOWER(CONCAT('%', :keyword, '%'))
+        """)
+    Page<BookEntity> findByKeyword(String keyword, Pageable pageable);
 }

--- a/src/main/java/org/example/booksearchservice/book/infrastructure/persistence/BookJpaRepository.java
+++ b/src/main/java/org/example/booksearchservice/book/infrastructure/persistence/BookJpaRepository.java
@@ -8,10 +8,20 @@ import org.springframework.data.jpa.repository.Query;
 public interface BookJpaRepository extends JpaRepository<BookEntity, Long> {
 
     @Query("""
-        SELECT b
-        FROM BookEntity b
-        WHERE LOWER(b.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
-           OR LOWER(b.subtitle) LIKE LOWER(CONCAT('%', :keyword, '%'))
-        """)
+            SELECT b
+            FROM BookEntity b
+            WHERE LOWER(b.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
+               OR LOWER(b.subtitle) LIKE LOWER(CONCAT('%', :keyword, '%'))
+            """)
     Page<BookEntity> findByKeyword(String keyword, Pageable pageable);
+
+    @Query("""
+            SELECT b
+            FROM BookEntity b
+            WHERE (LOWER(b.title) LIKE LOWER(CONCAT('%', :firstKeyword, '%'))
+               OR LOWER(b.subtitle) LIKE LOWER(CONCAT('%', :firstKeyword, '%')))
+               OR (LOWER(b.title) LIKE LOWER(CONCAT('%', :secondKeyword, '%'))
+               OR LOWER(b.subtitle) LIKE LOWER(CONCAT('%', :secondKeyword, '%')))
+            """)
+    Page<BookEntity> findByAnyKeywords(String firstKeyword, String secondKeyword, Pageable pageable);
 }

--- a/src/main/java/org/example/booksearchservice/book/infrastructure/persistence/LoadBookAdapter.java
+++ b/src/main/java/org/example/booksearchservice/book/infrastructure/persistence/LoadBookAdapter.java
@@ -26,4 +26,10 @@ public class LoadBookAdapter implements LoadBookPort {
         return bookJpaRepository.findByKeyword(keyword, pageable)
                 .map(BookEntity::toDomain);
     }
+
+    @Override
+    public Page<Book> loadByAnyKeywords(String firstKeyword, String secondKeyword, Pageable pageable) {
+        return bookJpaRepository.findByAnyKeywords(firstKeyword, secondKeyword, pageable)
+                .map(BookEntity::toDomain);
+    }
 }

--- a/src/main/java/org/example/booksearchservice/book/infrastructure/persistence/LoadBookAdapter.java
+++ b/src/main/java/org/example/booksearchservice/book/infrastructure/persistence/LoadBookAdapter.java
@@ -3,6 +3,8 @@ package org.example.booksearchservice.book.infrastructure.persistence;
 import lombok.RequiredArgsConstructor;
 import org.example.booksearchservice.book.application.port.LoadBookPort;
 import org.example.booksearchservice.book.domain.Book;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -16,6 +18,12 @@ public class LoadBookAdapter implements LoadBookPort {
     @Override
     public Optional<Book> loadById(Long id) {
         return bookJpaRepository.findById(id)
+                .map(BookEntity::toDomain);
+    }
+
+    @Override
+    public Page<Book> loadByKeyword(String keyword, Pageable pageable) {
+        return bookJpaRepository.findByKeyword(keyword, pageable)
                 .map(BookEntity::toDomain);
     }
 }

--- a/src/main/java/org/example/booksearchservice/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/booksearchservice/common/exception/ErrorCode.java
@@ -14,7 +14,11 @@ public enum ErrorCode {
     METHOD_ARGUMENT_NOT_VALID("유효하지 않은 요청 값입니다."),
 
     // Book
-    BOOK_NOT_FOUND("책을 찾을 수 없습니다.");
+    BOOK_NOT_FOUND("책을 찾을 수 없습니다."),
+
+    // Search
+    UNSUPPORTED_OPERATOR("지원하지 않는 검색 연산자입니다."),
+    INVALID_KEYWORD_COUNT("두 개의 키워드가 필요합니다.");
 
     private final String message;
 }

--- a/src/main/java/org/example/booksearchservice/common/exception/InvalidException.java
+++ b/src/main/java/org/example/booksearchservice/common/exception/InvalidException.java
@@ -1,0 +1,8 @@
+package org.example.booksearchservice.common.exception;
+
+public class InvalidException extends BusinessException {
+
+    public InvalidException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/application/aop/SearchExecutionTimeAspect.java
+++ b/src/main/java/org/example/booksearchservice/search/application/aop/SearchExecutionTimeAspect.java
@@ -1,0 +1,38 @@
+package org.example.booksearchservice.search.application.aop;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.example.booksearchservice.search.application.dto.SearchMetaData;
+import org.example.booksearchservice.search.application.dto.SearchResponse;
+import org.springframework.stereotype.Component;
+
+import static java.lang.System.currentTimeMillis;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class SearchExecutionTimeAspect {
+
+    @Around("execution(* org.example.booksearchservice.search.application.service.SearchService.*(..))")
+    public Object recordExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        long start = currentTimeMillis();
+        Object result = joinPoint.proceed();
+        long executionTime = currentTimeMillis() - start;
+
+        if (result instanceof SearchResponse response) {
+            return SearchResponse.of(
+                response.searchQuery(),
+                response.pageInfo(),
+                response.books(),
+                SearchMetaData.of(
+                    executionTime,
+                    response.searchMetaData().strategy()
+                )
+            );
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/application/dto/SearchMetaData.java
+++ b/src/main/java/org/example/booksearchservice/search/application/dto/SearchMetaData.java
@@ -1,0 +1,19 @@
+package org.example.booksearchservice.search.application.dto;
+
+import org.example.booksearchservice.search.domain.SearchOperator;
+
+public record SearchMetaData(
+        Long executionTime,
+        SearchOperator strategy
+) {
+    public static SearchMetaData ofDefaultExecutionTime(SearchOperator strategy) {
+        return new SearchMetaData(0L, strategy);
+    }
+
+    public static SearchMetaData of(Long executionTime, SearchOperator searchOperator) {
+        return new SearchMetaData(
+                executionTime,
+                searchOperator
+        );
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/application/dto/SearchResponse.java
+++ b/src/main/java/org/example/booksearchservice/search/application/dto/SearchResponse.java
@@ -1,0 +1,27 @@
+package org.example.booksearchservice.search.application.dto;
+
+import org.example.booksearchservice.book.application.dto.BookDetailResponse;
+import org.example.booksearchservice.book.application.dto.PageInfo;
+
+import java.util.List;
+
+public record SearchResponse(
+        String searchQuery,
+        PageInfo pageInfo,
+        List<BookDetailResponse> books,
+        SearchMetaData searchMetaData
+) {
+    public static SearchResponse of(
+            String searchQuery,
+            PageInfo pageInfo,
+            List<BookDetailResponse> books,
+            SearchMetaData searchMetaData
+    ) {
+        return new SearchResponse(
+                searchQuery,
+                pageInfo,
+                books,
+                searchMetaData
+        );
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/application/port/BookInternalPort.java
+++ b/src/main/java/org/example/booksearchservice/search/application/port/BookInternalPort.java
@@ -1,0 +1,8 @@
+package org.example.booksearchservice.search.application.port;
+
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface BookInternalPort {
+    BookPageResponse findBooksByKeyword(String keyword, Pageable pageable);
+}

--- a/src/main/java/org/example/booksearchservice/search/application/port/BookInternalPort.java
+++ b/src/main/java/org/example/booksearchservice/search/application/port/BookInternalPort.java
@@ -5,4 +5,5 @@ import org.springframework.data.domain.Pageable;
 
 public interface BookInternalPort {
     BookPageResponse findBooksByKeyword(String keyword, Pageable pageable);
+    BookPageResponse findBooksByAnyKeyword(String firstKeyword, String secondKeyword, Pageable pageable);
 }

--- a/src/main/java/org/example/booksearchservice/search/application/service/SearchQueryParser.java
+++ b/src/main/java/org/example/booksearchservice/search/application/service/SearchQueryParser.java
@@ -1,0 +1,51 @@
+package org.example.booksearchservice.search.application.service;
+
+import org.example.booksearchservice.search.domain.SearchOperator;
+import org.example.booksearchservice.search.domain.SearchQuery;
+import org.example.booksearchservice.search.exception.InvalidSearchQueryException;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.example.booksearchservice.common.exception.ErrorCode.*;
+import static org.example.booksearchservice.search.domain.SearchOperator.OR;
+
+@Component
+public class SearchQueryParser {
+
+    public SearchQuery parse(String query) {
+        SearchOperator operator = extractOperator(query);
+        List<String> keywords = extractKeywords(query, operator);
+        validateKeywords(keywords);
+        return buildSearchQuery(keywords, operator);
+    }
+
+    private SearchOperator extractOperator(String query) {
+        if (query.contains(OR.getQuerySymbol())) {
+            return OR;
+        }
+        throw new InvalidSearchQueryException(UNSUPPORTED_OPERATOR);
+    }
+
+    private List<String> extractKeywords(String query, SearchOperator operator) {
+        return Arrays.stream(query.split(operator.getSplitRegex()))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+
+    private void validateKeywords(List<String> keywords) {
+        if (keywords.size() != 2) {
+            throw new InvalidSearchQueryException(INVALID_KEYWORD_COUNT);
+        }
+    }
+
+    private SearchQuery buildSearchQuery(List<String> keywords, SearchOperator operator) {
+        return SearchQuery.builder()
+                .firstKeyword(keywords.get(0))
+                .secondKeyword(keywords.get(1))
+                .operator(operator)
+                .build();
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/application/service/SearchService.java
+++ b/src/main/java/org/example/booksearchservice/search/application/service/SearchService.java
@@ -4,9 +4,14 @@ import lombok.RequiredArgsConstructor;
 import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.search.application.dto.SearchMetaData;
 import org.example.booksearchservice.search.application.dto.SearchResponse;
+import org.example.booksearchservice.search.application.usecase.OperatorSearchUseCase;
 import org.example.booksearchservice.search.application.usecase.KeywordSearchUseCase;
+import org.example.booksearchservice.search.domain.SearchOperator;
+import org.example.booksearchservice.search.domain.SearchQuery;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.Map;
 
 import static org.example.booksearchservice.search.domain.SearchOperator.NONE;
 
@@ -15,14 +20,34 @@ import static org.example.booksearchservice.search.domain.SearchOperator.NONE;
 public class SearchService {
 
     private final KeywordSearchUseCase keywordSearchUseCase;
+    private final Map<String, OperatorSearchUseCase> operatorSearchUseCaseMap;
+    private final SearchQueryParser searchQueryParser;
 
     public SearchResponse searchBooksByKeyword(String keyword, Pageable pageable) {
         BookPageResponse bookPageResponse = keywordSearchUseCase.execute(keyword, pageable);
+        return buildSearchResponse(keyword, bookPageResponse, NONE);
+    }
+
+    public SearchResponse searchBooksByComplexQuery(String query, Pageable pageable) {
+        SearchQuery searchQuery = searchQueryParser.parse(query);
+        SearchOperator searchOperator = searchQuery.getOperator();
+
+        OperatorSearchUseCase operatorSearchUseCase = operatorSearchUseCaseMap.get(searchOperator.name());
+        BookPageResponse bookPageResponse = operatorSearchUseCase.execute(
+                searchQuery.getFirstKeyword(),
+                searchQuery.getSecondKeyword(),
+                pageable
+        );
+
+        return buildSearchResponse(query, bookPageResponse, searchOperator);
+    }
+
+    private SearchResponse buildSearchResponse(String query, BookPageResponse bookPageResponse, SearchOperator searchOperator) {
         return SearchResponse.of(
-                keyword,
+                query,
                 bookPageResponse.pageInfo(),
                 bookPageResponse.books(),
-                SearchMetaData.ofDefaultExecutionTime(NONE)
+                SearchMetaData.ofDefaultExecutionTime(searchOperator)
         );
     }
 }

--- a/src/main/java/org/example/booksearchservice/search/application/service/SearchService.java
+++ b/src/main/java/org/example/booksearchservice/search/application/service/SearchService.java
@@ -1,0 +1,28 @@
+package org.example.booksearchservice.search.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.example.booksearchservice.search.application.dto.SearchMetaData;
+import org.example.booksearchservice.search.application.dto.SearchResponse;
+import org.example.booksearchservice.search.application.usecase.KeywordSearchUseCase;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import static org.example.booksearchservice.search.domain.SearchOperator.NONE;
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+
+    private final KeywordSearchUseCase keywordSearchUseCase;
+
+    public SearchResponse searchBooksByKeyword(String keyword, Pageable pageable) {
+        BookPageResponse bookPageResponse = keywordSearchUseCase.execute(keyword, pageable);
+        return SearchResponse.of(
+                keyword,
+                bookPageResponse.pageInfo(),
+                bookPageResponse.books(),
+                SearchMetaData.ofDefaultExecutionTime(NONE)
+        );
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/application/usecase/KeywordSearchUseCase.java
+++ b/src/main/java/org/example/booksearchservice/search/application/usecase/KeywordSearchUseCase.java
@@ -1,0 +1,23 @@
+package org.example.booksearchservice.search.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.example.booksearchservice.search.application.port.BookInternalPort;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KeywordSearchUseCase {
+
+    private final BookInternalPort bookInternalPort;
+
+    @Transactional(readOnly = true)
+    public BookPageResponse execute(String keyword, Pageable pageable) {
+        log.info("Executing keyword search for keyword: [{}]", keyword);
+        return bookInternalPort.findBooksByKeyword(keyword, pageable);
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/application/usecase/OperatorSearchUseCase.java
+++ b/src/main/java/org/example/booksearchservice/search/application/usecase/OperatorSearchUseCase.java
@@ -1,0 +1,9 @@
+package org.example.booksearchservice.search.application.usecase;
+
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface OperatorSearchUseCase {
+    BookPageResponse execute(String firstKeyword, String secondKeyword, Pageable pageable);
+}
+

--- a/src/main/java/org/example/booksearchservice/search/application/usecase/OrSearchUseCase.java
+++ b/src/main/java/org/example/booksearchservice/search/application/usecase/OrSearchUseCase.java
@@ -1,0 +1,25 @@
+package org.example.booksearchservice.search.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.example.booksearchservice.search.application.port.BookInternalPort;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service("OR")
+@RequiredArgsConstructor
+public class OrSearchUseCase implements OperatorSearchUseCase {
+
+    private final BookInternalPort bookInternalPort;
+
+    @Override
+    @Transactional(readOnly = true)
+    public BookPageResponse execute(String firstKeyword, String secondKeyword, Pageable pageable) {
+        log.info("Executing OR search with firstKeyword: [{}], secondKeyword: [{}]",
+                firstKeyword, secondKeyword);
+        return bookInternalPort.findBooksByAnyKeyword(firstKeyword, secondKeyword, pageable);
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/domain/SearchOperator.java
+++ b/src/main/java/org/example/booksearchservice/search/domain/SearchOperator.java
@@ -1,0 +1,15 @@
+package org.example.booksearchservice.search.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SearchOperator {
+    NONE("", ""),
+    OR("|", "\\|"),
+    NOT("-", "-");
+
+    private final String querySymbol;
+    private final String splitRegex;
+}

--- a/src/main/java/org/example/booksearchservice/search/domain/SearchQuery.java
+++ b/src/main/java/org/example/booksearchservice/search/domain/SearchQuery.java
@@ -1,0 +1,19 @@
+package org.example.booksearchservice.search.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SearchQuery {
+
+    private final String firstKeyword;
+    private final String secondKeyword;
+    private final SearchOperator operator;
+
+    @Builder
+    private SearchQuery(String firstKeyword, String secondKeyword, SearchOperator operator) {
+        this.firstKeyword = firstKeyword;
+        this.secondKeyword = secondKeyword;
+        this.operator = operator;
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/exception/InvalidSearchQueryException.java
+++ b/src/main/java/org/example/booksearchservice/search/exception/InvalidSearchQueryException.java
@@ -1,0 +1,11 @@
+package org.example.booksearchservice.search.exception;
+
+import org.example.booksearchservice.common.exception.ErrorCode;
+import org.example.booksearchservice.common.exception.InvalidException;
+
+public class InvalidSearchQueryException extends InvalidException {
+
+    public InvalidSearchQueryException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/infrastructure/internal/BookInternalAdapter.java
+++ b/src/main/java/org/example/booksearchservice/search/infrastructure/internal/BookInternalAdapter.java
@@ -1,0 +1,20 @@
+package org.example.booksearchservice.search.infrastructure.internal;
+
+import lombok.RequiredArgsConstructor;
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.example.booksearchservice.book.application.service.BookQueryService;
+import org.example.booksearchservice.search.application.port.BookInternalPort;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BookInternalAdapter implements BookInternalPort {
+
+    private final BookQueryService bookQueryService;
+
+    @Override
+    public BookPageResponse findBooksByKeyword(String keyword, Pageable pageable) {
+        return bookQueryService.findBooksByKeyword(keyword, pageable);
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/infrastructure/internal/BookInternalAdapter.java
+++ b/src/main/java/org/example/booksearchservice/search/infrastructure/internal/BookInternalAdapter.java
@@ -17,4 +17,9 @@ public class BookInternalAdapter implements BookInternalPort {
     public BookPageResponse findBooksByKeyword(String keyword, Pageable pageable) {
         return bookQueryService.findBooksByKeyword(keyword, pageable);
     }
+
+    @Override
+    public BookPageResponse findBooksByAnyKeyword(String firstKeyword, String secondKeyword, Pageable pageable) {
+        return bookQueryService.findBooksByAnyKeyword(firstKeyword, secondKeyword, pageable);
+    }
 }

--- a/src/main/java/org/example/booksearchservice/search/presentation/dto/ComplexSearchRequest.java
+++ b/src/main/java/org/example/booksearchservice/search/presentation/dto/ComplexSearchRequest.java
@@ -2,8 +2,8 @@ package org.example.booksearchservice.search.presentation.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record SearchRequest(
+public record ComplexSearchRequest(
         @NotBlank(message = "검색어 입력은 필수입니다.")
-        String searchQuery
+        String query
 ) {
 }

--- a/src/main/java/org/example/booksearchservice/search/presentation/dto/KeywordSearchRequest.java
+++ b/src/main/java/org/example/booksearchservice/search/presentation/dto/KeywordSearchRequest.java
@@ -1,0 +1,9 @@
+package org.example.booksearchservice.search.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record KeywordSearchRequest(
+        @NotBlank(message = "검색어 입력은 필수입니다.")
+        String keyword
+) {
+}

--- a/src/main/java/org/example/booksearchservice/search/presentation/dto/SearchRequest.java
+++ b/src/main/java/org/example/booksearchservice/search/presentation/dto/SearchRequest.java
@@ -2,8 +2,8 @@ package org.example.booksearchservice.search.presentation.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record KeywordSearchRequest(
+public record SearchRequest(
         @NotBlank(message = "검색어 입력은 필수입니다.")
-        String keyword
+        String searchQuery
 ) {
 }

--- a/src/main/java/org/example/booksearchservice/search/presentation/dto/SimpleSearchRequest.java
+++ b/src/main/java/org/example/booksearchservice/search/presentation/dto/SimpleSearchRequest.java
@@ -1,0 +1,9 @@
+package org.example.booksearchservice.search.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SimpleSearchRequest(
+        @NotBlank(message = "검색어 입력은 필수입니다.")
+        String keyword
+) {
+}

--- a/src/main/java/org/example/booksearchservice/search/presentation/web/SearchController.java
+++ b/src/main/java/org/example/booksearchservice/search/presentation/web/SearchController.java
@@ -4,7 +4,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.booksearchservice.search.application.dto.SearchResponse;
 import org.example.booksearchservice.search.application.service.SearchService;
-import org.example.booksearchservice.search.presentation.dto.KeywordSearchRequest;
+import org.example.booksearchservice.search.presentation.dto.ComplexSearchRequest;
+import org.example.booksearchservice.search.presentation.dto.SimpleSearchRequest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -20,14 +21,25 @@ public class SearchController {
     private static final String  DEFAULT_PAGE = "0";
     private static final String DEFAULT_SIZE = "20";
 
-    @GetMapping
+    @GetMapping("/simple")
     public ResponseEntity<SearchResponse> searchBooks(
-            @Valid @ModelAttribute KeywordSearchRequest request,
+            @Valid @ModelAttribute SimpleSearchRequest request,
             @RequestParam(defaultValue = DEFAULT_PAGE) int page,
             @RequestParam(defaultValue = DEFAULT_SIZE) int size) {
 
         Pageable pageable = PageRequest.of(page, size);
         SearchResponse response = searchService.searchBooksByKeyword(request.keyword(), pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping ("/complex")
+    public ResponseEntity<SearchResponse> searchBooksByComplexQuery(
+            @Valid @ModelAttribute ComplexSearchRequest request,
+            @RequestParam(defaultValue = DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = DEFAULT_SIZE) int size) {
+
+        Pageable pageable = PageRequest.of(page, size);
+        SearchResponse response = searchService.searchBooksByComplexQuery(request.query(), pageable);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/org/example/booksearchservice/search/presentation/web/SearchController.java
+++ b/src/main/java/org/example/booksearchservice/search/presentation/web/SearchController.java
@@ -1,0 +1,33 @@
+package org.example.booksearchservice.search.presentation.web;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.booksearchservice.search.application.dto.SearchResponse;
+import org.example.booksearchservice.search.application.service.SearchService;
+import org.example.booksearchservice.search.presentation.dto.KeywordSearchRequest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/search/books")
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final SearchService searchService;
+
+    private static final String  DEFAULT_PAGE = "0";
+    private static final String DEFAULT_SIZE = "20";
+
+    @GetMapping
+    public ResponseEntity<SearchResponse> searchBooks(
+            @Valid @ModelAttribute KeywordSearchRequest request,
+            @RequestParam(defaultValue = DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = DEFAULT_SIZE) int size) {
+
+        Pageable pageable = PageRequest.of(page, size);
+        SearchResponse response = searchService.searchBooksByKeyword(request.keyword(), pageable);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/test/java/org/example/booksearchservice/book/application/service/BookQueryServiceTest.java
+++ b/src/test/java/org/example/booksearchservice/book/application/service/BookQueryServiceTest.java
@@ -3,6 +3,7 @@ package org.example.booksearchservice.book.application.service;
 import org.example.booksearchservice.book.application.dto.BookDetailResponse;
 import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.book.application.usecase.LoadBookDetailUseCase;
+import org.example.booksearchservice.book.application.usecase.LoadBooksByAnyKeywordUseCase;
 import org.example.booksearchservice.book.application.usecase.LoadBooksByKeywordUseCase;
 import org.example.booksearchservice.book.domain.Book;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,13 +25,15 @@ class BookQueryServiceTest {
 
     private LoadBookDetailUseCase loadBookUseCase;
     private LoadBooksByKeywordUseCase loadBooksByKeywordUseCase;
+    private LoadBooksByAnyKeywordUseCase loadBooksByAnyKeywordUseCase;
     private BookQueryService bookQueryService;
 
     @BeforeEach
     void setUp() {
         loadBookUseCase = mock(LoadBookDetailUseCase.class);
         loadBooksByKeywordUseCase = mock(LoadBooksByKeywordUseCase.class);
-        bookQueryService = new BookQueryService(loadBookUseCase, loadBooksByKeywordUseCase);
+        loadBooksByAnyKeywordUseCase = mock(LoadBooksByAnyKeywordUseCase.class);
+        bookQueryService = new BookQueryService(loadBookUseCase, loadBooksByKeywordUseCase, loadBooksByAnyKeywordUseCase);
     }
 
     @Test
@@ -63,6 +66,26 @@ class BookQueryServiceTest {
 
         // when
         BookPageResponse response = bookQueryService.findBooksByKeyword(keyword, pageable);
+
+        // then
+        assertThat(response.books().getFirst().isbn()).isEqualTo(books.getFirst().getIsbn());
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 두 개의 키워드와 페이징 정보로 책 목록을 조회하면 페이지 응답을 반환한다")
+    void findBooksByAnyKeyword_givenTwoKeywordsAndPageable_returnsBookPageResponse() {
+        // given
+        String firstKeyword = "java";
+        String secondKeyword = "spring";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        List<Book> books = List.of(createBook());
+        Page<Book> bookPage = new PageImpl<>(books, pageable, books.size());
+
+        when(loadBooksByAnyKeywordUseCase.execute(firstKeyword, secondKeyword, pageable)).thenReturn(bookPage);
+
+        // when
+        BookPageResponse response = bookQueryService.findBooksByAnyKeyword(firstKeyword, secondKeyword, pageable);
 
         // then
         assertThat(response.books().getFirst().isbn()).isEqualTo(books.getFirst().getIsbn());

--- a/src/test/java/org/example/booksearchservice/book/application/service/BookQueryServiceTest.java
+++ b/src/test/java/org/example/booksearchservice/book/application/service/BookQueryServiceTest.java
@@ -1,33 +1,40 @@
 package org.example.booksearchservice.book.application.service;
 
 import org.example.booksearchservice.book.application.dto.BookDetailResponse;
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.book.application.usecase.LoadBookDetailUseCase;
-import org.example.booksearchservice.book.domain.BasicInfo;
+import org.example.booksearchservice.book.application.usecase.LoadBooksByKeywordUseCase;
 import org.example.booksearchservice.book.domain.Book;
-import org.example.booksearchservice.book.domain.PublicationInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
-import java.time.LocalDate;
+import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.example.booksearchservice.fixture.BookFixture.createBook;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class BookQueryServiceTest {
 
     private LoadBookDetailUseCase loadBookUseCase;
+    private LoadBooksByKeywordUseCase loadBooksByKeywordUseCase;
     private BookQueryService bookQueryService;
 
     @BeforeEach
     void setUp() {
         loadBookUseCase = mock(LoadBookDetailUseCase.class);
-        bookQueryService = new BookQueryService(loadBookUseCase);
+        loadBooksByKeywordUseCase = mock(LoadBooksByKeywordUseCase.class);
+        bookQueryService = new BookQueryService(loadBookUseCase, loadBooksByKeywordUseCase);
     }
 
     @Test
-    @DisplayName("[SUCCESS] 유효한 책 ID로 조회하면 BookDetailResponse를 반환한다")
+    @DisplayName("[SUCCESS] 책 ID로 책 상세 정보를 조회하면 책 상세 응답을 반환한다")
     void getBookDetail_givenExistingBookId_returnsBookDetailResponse() {
         // given
         Long bookId = 1L;
@@ -41,22 +48,23 @@ class BookQueryServiceTest {
         assertThat(response.isbn()).isEqualTo(book.getIsbn());
     }
 
-    private Book createBook() {
-        BasicInfo basicInfo = BasicInfo.builder()
-                .title("Effective Java")
-                .subtitle("Programming Language Guide")
-                .author("Joshua Bloch")
-                .build();
 
-        PublicationInfo pubInfo = PublicationInfo.builder()
-                .publisher("Addison-Wesley")
-                .publishedDate(LocalDate.of(2018, 1, 11))
-                .build();
+    @Test
+    @DisplayName("[SUCCESS] 키워드와 페이징 정보를 이용해 책 목록을 조회하면 페이지 응답을 반환한다")
+    void findBooksByKeyword_givenKeywordAndPageable_returnsBookPageResponse() {
+        // given
+        String keyword = "java";
+        Pageable pageable = PageRequest.of(0, 10);
 
-        return Book.builder()
-                .isbn("978-3-16-148410-0")
-                .basicInfo(basicInfo)
-                .publicationInfo(pubInfo)
-                .build();
+        List<Book> books = List.of(createBook());
+        Page<Book> bookPage = new PageImpl<>(books, pageable, books.size());
+
+        when(loadBooksByKeywordUseCase.execute(keyword, pageable)).thenReturn(bookPage);
+
+        // when
+        BookPageResponse response = bookQueryService.findBooksByKeyword(keyword, pageable);
+
+        // then
+        assertThat(response.books().getFirst().isbn()).isEqualTo(books.getFirst().getIsbn());
     }
 }

--- a/src/test/java/org/example/booksearchservice/book/application/usecase/LoadBooksByAnyKeywordUseCaseTest.java
+++ b/src/test/java/org/example/booksearchservice/book/application/usecase/LoadBooksByAnyKeywordUseCaseTest.java
@@ -1,0 +1,46 @@
+package org.example.booksearchservice.book.application.usecase;
+
+import org.example.booksearchservice.book.domain.Book;
+import org.example.booksearchservice.mock.FakeLoadBookAdapter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LoadBooksByAnyKeywordUseCaseTest {
+
+    private LoadBooksByAnyKeywordUseCase loadBooksByAnyKeywordUseCase;
+
+    @BeforeEach
+    void setUp() {
+        FakeLoadBookAdapter fakeLoadBookAdapter = new FakeLoadBookAdapter();
+        loadBooksByAnyKeywordUseCase = new LoadBooksByAnyKeywordUseCase(fakeLoadBookAdapter);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 두 키워드 중 하나라도 포함하는 도서 목록을 페이징하여 조회할 수 있다")
+    void execute_givenTwoKeywordsAndPageable_returnsMatchingBooks() {
+        // given
+        String firstKeyword = "java";
+        String secondKeyword = "spring";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<Book> bookPage = loadBooksByAnyKeywordUseCase.execute(firstKeyword, secondKeyword, pageable);
+
+        // then
+        assertThat(bookPage.getNumber()).isEqualTo(pageable.getPageNumber());
+        assertThat(bookPage.getSize()).isEqualTo(pageable.getPageSize());
+        assertThat(bookPage.getContent().stream()
+                .anyMatch(book ->
+                        book.getBasicInfo().getTitle().toLowerCase().contains(firstKeyword) ||
+                                book.getBasicInfo().getSubtitle().toLowerCase().contains(firstKeyword) ||
+                                book.getBasicInfo().getTitle().toLowerCase().contains(secondKeyword) ||
+                                book.getBasicInfo().getSubtitle().toLowerCase().contains(secondKeyword)))
+                .isTrue();
+    }
+}

--- a/src/test/java/org/example/booksearchservice/book/application/usecase/LoadBooksByKeywordUseCaseTest.java
+++ b/src/test/java/org/example/booksearchservice/book/application/usecase/LoadBooksByKeywordUseCaseTest.java
@@ -1,0 +1,40 @@
+package org.example.booksearchservice.book.application.usecase;
+
+import org.example.booksearchservice.book.domain.Book;
+import org.example.booksearchservice.mock.FakeLoadBookAdapter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+class LoadBooksByKeywordUseCaseTest {
+
+    private LoadBooksByKeywordUseCase loadBooksByKeywordUseCase;
+
+    @BeforeEach
+    void setUp() {
+        FakeLoadBookAdapter fakeLoadBookAdapter = new FakeLoadBookAdapter();
+        loadBooksByKeywordUseCase = new LoadBooksByKeywordUseCase(fakeLoadBookAdapter);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 키워드와 페이징으로 도서 목록을 조회할 수 있다")
+    void execute_givenKeywordAndPageable_returnsBooks() {
+        // given
+        String keyword = "java";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<Book> bookPage = loadBooksByKeywordUseCase.execute(keyword, pageable);
+
+        // then
+        assertThat(bookPage.getContent()).isNotNull();
+        assertThat(bookPage.getNumber()).isEqualTo(pageable.getPageNumber());
+        assertThat(bookPage.getSize()).isEqualTo(pageable.getPageSize());
+    }
+}
+

--- a/src/test/java/org/example/booksearchservice/book/presentation/BookControllerTest.java
+++ b/src/test/java/org/example/booksearchservice/book/presentation/BookControllerTest.java
@@ -1,8 +1,5 @@
 package org.example.booksearchservice.book.presentation;
 
-import org.example.booksearchservice.book.domain.BasicInfo;
-import org.example.booksearchservice.book.domain.Book;
-import org.example.booksearchservice.book.domain.PublicationInfo;
 import org.example.booksearchservice.book.infrastructure.persistence.BookEntity;
 import org.example.booksearchservice.book.infrastructure.persistence.BookJpaRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,8 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.time.LocalDate;
-
+import static org.example.booksearchservice.fixture.BookFixture.createBook;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -35,13 +31,14 @@ class BookControllerTest {
 
     @BeforeEach
     void setup() {
+        bookJpaRepository.deleteAll();
         BookEntity bookEntity = BookEntity.fromDomain(createBook());
         savedBookEntity = bookJpaRepository.save(bookEntity);
     }
 
     @Test
-    @DisplayName("[SUCCESS] 책 상세 조회 API 호출 시 DB와 연동하여 응답 반환")
-    void getBookDetail_Success() throws Exception {
+    @DisplayName("[SUCCESS] 도서 상세 조회 시, 200 OK 및 조회 결과를 반환한다")
+    void getBookDetail_success() throws Exception {
         mockMvc.perform(get("/api/books/" + savedBookEntity.getId())
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -51,24 +48,5 @@ class BookControllerTest {
                 .andExpect(jsonPath("$.author").value("Joshua Bloch"))
                 .andExpect(jsonPath("$.publisher").value("Addison-Wesley"))
                 .andExpect(jsonPath("$.published").value("2018-01-11"));
-    }
-
-    private Book createBook() {
-        BasicInfo basicInfo = BasicInfo.builder()
-                .title("Effective Java")
-                .subtitle("Programming Language Guide")
-                .author("Joshua Bloch")
-                .build();
-
-        PublicationInfo pubInfo = PublicationInfo.builder()
-                .publisher("Addison-Wesley")
-                .publishedDate(LocalDate.of(2018, 1, 11))
-                .build();
-
-        return Book.builder()
-                .isbn("978-3-16-148410-0")
-                .basicInfo(basicInfo)
-                .publicationInfo(pubInfo)
-                .build();
     }
 }

--- a/src/test/java/org/example/booksearchservice/fixture/BookFixture.java
+++ b/src/test/java/org/example/booksearchservice/fixture/BookFixture.java
@@ -5,6 +5,8 @@ import org.example.booksearchservice.book.domain.Book;
 import org.example.booksearchservice.book.domain.PublicationInfo;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
 
 public class BookFixture {
 
@@ -21,5 +23,44 @@ public class BookFixture {
                         .publishedDate(LocalDate.of(2018, 1, 11))
                         .build())
                 .build();
+    }
+
+    public static List<Book> createBooks(int count) {
+        List<String> titles = List.of(
+                "Effective Java",
+                "Clean Code",
+                "Java Concurrency in Practice",
+                "Spring in Action",
+                "Domain-Driven Design"
+        );
+        List<String> subtitles = List.of(
+                "Programming Language Guide",
+                "A Handbook of Agile Software Craftsmanship",
+                "Concurrency Concepts and Examples",
+                "Comprehensive Guide to Spring Framework",
+                "Tackling Complexity in the Heart of Software"
+        );
+        List<String> authors = List.of(
+                "Joshua Bloch",
+                "Robert C. Martin",
+                "Brian Goetz",
+                "Craig Walls",
+                "Eric Evans"
+        );
+
+        return IntStream.range(0, count)
+                .mapToObj(i -> Book.builder()
+                        .isbn("978-3-16-1484" + (100 + i) + "-0")
+                        .basicInfo(BasicInfo.builder()
+                                .title(titles.get(i % titles.size()))
+                                .subtitle(subtitles.get(i % subtitles.size()))
+                                .author(authors.get(i % authors.size()))
+                                .build())
+                        .publicationInfo(PublicationInfo.builder()
+                                .publisher("Publisher " + (i + 1))
+                                .publishedDate(LocalDate.of(2018, 1, 11).plusDays(i))
+                                .build())
+                        .build())
+                .toList();
     }
 }

--- a/src/test/java/org/example/booksearchservice/fixture/BookFixture.java
+++ b/src/test/java/org/example/booksearchservice/fixture/BookFixture.java
@@ -1,0 +1,25 @@
+package org.example.booksearchservice.fixture;
+
+import org.example.booksearchservice.book.domain.BasicInfo;
+import org.example.booksearchservice.book.domain.Book;
+import org.example.booksearchservice.book.domain.PublicationInfo;
+
+import java.time.LocalDate;
+
+public class BookFixture {
+
+    public static Book createBook() {
+        return Book.builder()
+                .isbn("978-3-16-148410-0")
+                .basicInfo(BasicInfo.builder()
+                        .title("Effective Java")
+                        .subtitle("Programming Language Guide")
+                        .author("Joshua Bloch")
+                        .build())
+                .publicationInfo(PublicationInfo.builder()
+                        .publisher("Addison-Wesley")
+                        .publishedDate(LocalDate.of(2018, 1, 11))
+                        .build())
+                .build();
+    }
+}

--- a/src/test/java/org/example/booksearchservice/mock/FakeBookInternalAdapter.java
+++ b/src/test/java/org/example/booksearchservice/mock/FakeBookInternalAdapter.java
@@ -1,0 +1,22 @@
+package org.example.booksearchservice.mock;
+
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.example.booksearchservice.book.domain.Book;
+import org.example.booksearchservice.search.application.port.BookInternalPort;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static org.example.booksearchservice.fixture.BookFixture.createBook;
+
+public class FakeBookInternalAdapter implements BookInternalPort {
+
+    @Override
+    public BookPageResponse findBooksByKeyword(String keyword, Pageable pageable) {
+        List<Book> books = List.of(createBook());
+        Page<Book> bookPage = new PageImpl<>(books, pageable, books.size());
+        return BookPageResponse.of(bookPage);
+    }
+}

--- a/src/test/java/org/example/booksearchservice/mock/FakeBookInternalAdapter.java
+++ b/src/test/java/org/example/booksearchservice/mock/FakeBookInternalAdapter.java
@@ -9,14 +9,34 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
-import static org.example.booksearchservice.fixture.BookFixture.createBook;
+import static org.example.booksearchservice.fixture.BookFixture.createBooks;
 
 public class FakeBookInternalAdapter implements BookInternalPort {
 
     @Override
     public BookPageResponse findBooksByKeyword(String keyword, Pageable pageable) {
-        List<Book> books = List.of(createBook());
-        Page<Book> bookPage = new PageImpl<>(books, pageable, books.size());
+        List<Book> filteredBooks = filterBooksByKeywords(List.of(keyword));
+        Page<Book> bookPage = new PageImpl<>(filteredBooks, pageable, filteredBooks.size());
         return BookPageResponse.of(bookPage);
+    }
+
+    @Override
+    public BookPageResponse findBooksByAnyKeyword(String firstKeyword, String secondKeyword, Pageable pageable) {
+        List<Book> filteredBooks = filterBooksByKeywords(List.of(firstKeyword, secondKeyword));
+        Page<Book> bookPage = new PageImpl<>(filteredBooks, pageable, filteredBooks.size());
+        return BookPageResponse.of(bookPage);
+    }
+
+    private List<Book> filterBooksByKeywords(List<String> keywords) {
+        List<Book> allBooks = createBooks(5);
+        return allBooks.stream()
+                .filter(book -> keywords.stream().anyMatch(keyword -> containsKeyword(book, keyword)))
+                .toList();
+    }
+
+    private boolean containsKeyword(Book book, String keyword) {
+        String lowerKeyword = keyword.toLowerCase();
+        return book.getBasicInfo().getTitle().toLowerCase().contains(lowerKeyword) ||
+                book.getBasicInfo().getSubtitle().toLowerCase().contains(lowerKeyword);
     }
 }

--- a/src/test/java/org/example/booksearchservice/mock/FakeLoadBookAdapter.java
+++ b/src/test/java/org/example/booksearchservice/mock/FakeLoadBookAdapter.java
@@ -70,4 +70,26 @@ public class FakeLoadBookAdapter implements LoadBookPort {
 
         return new PageImpl<>(pagedBooks, pageable, filteredBooks.size());
     }
+
+    @Override
+    public Page<Book> loadByAnyKeywords(String firstKeyword, String secondKeyword, Pageable pageable) {
+        List<Book> filteredBooks = store.values().stream()
+                .filter(book -> {
+                    String title = book.getBasicInfo().getTitle().toLowerCase();
+                    String subtitle = book.getBasicInfo().getSubtitle().toLowerCase();
+                    return title.contains(firstKeyword.toLowerCase()) ||
+                            subtitle.contains(firstKeyword.toLowerCase()) ||
+                            title.contains(secondKeyword.toLowerCase()) ||
+                            subtitle.contains(secondKeyword.toLowerCase());
+                })
+                .toList();
+
+        int pageOffset = toIntExact(pageable.getOffset());
+        int pageLimit = min(pageOffset + pageable.getPageSize(), filteredBooks.size());
+        List<Book> pagedBooks = (pageOffset <= pageLimit)
+                ? filteredBooks.subList(pageOffset, pageLimit)
+                : List.of();
+
+        return new PageImpl<>(pagedBooks, pageable, filteredBooks.size());
+    }
 }

--- a/src/test/java/org/example/booksearchservice/mock/FakeLoadBookAdapter.java
+++ b/src/test/java/org/example/booksearchservice/mock/FakeLoadBookAdapter.java
@@ -4,11 +4,18 @@ import org.example.booksearchservice.book.application.port.LoadBookPort;
 import org.example.booksearchservice.book.domain.BasicInfo;
 import org.example.booksearchservice.book.domain.Book;
 import org.example.booksearchservice.book.domain.PublicationInfo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
 
 public class FakeLoadBookAdapter implements LoadBookPort {
 
@@ -44,5 +51,23 @@ public class FakeLoadBookAdapter implements LoadBookPort {
     @Override
     public Optional<Book> loadById(Long id) {
         return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Page<Book> loadByKeyword(String keyword, Pageable pageable) {
+        List<Book> filteredBooks = store.values().stream()
+                .filter(book -> book.getBasicInfo()
+                        .getTitle()
+                        .toLowerCase()
+                        .contains(keyword.toLowerCase()))
+                .toList();
+
+        int pageOffset = toIntExact(pageable.getOffset());
+        int pageLimit = min((pageOffset + pageable.getPageSize()), filteredBooks.size());
+        List<Book> pagedBooks = (pageOffset <= pageLimit)
+                ? filteredBooks.subList(pageOffset, pageLimit)
+                : List.of();
+
+        return new PageImpl<>(pagedBooks, pageable, filteredBooks.size());
     }
 }

--- a/src/test/java/org/example/booksearchservice/search/presentation/SearchControllerTest.java
+++ b/src/test/java/org/example/booksearchservice/search/presentation/SearchControllerTest.java
@@ -1,0 +1,68 @@
+package org.example.booksearchservice.search.presentation;
+
+import org.example.booksearchservice.book.infrastructure.persistence.BookEntity;
+import org.example.booksearchservice.book.infrastructure.persistence.BookJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.example.booksearchservice.fixture.BookFixture.createBook;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@AutoConfigureMockMvc
+public class SearchControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private BookJpaRepository bookJpaRepository;
+
+    private BookEntity savedBookEntity;
+
+    @BeforeEach
+    void setup() {
+        bookJpaRepository.deleteAll();
+        BookEntity bookEntity = BookEntity.fromDomain(createBook());
+        savedBookEntity = bookJpaRepository.save(bookEntity);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 키워드로 책을 검색하면, 200 OK 및 검색 결과를 반환한다")
+    void searchBooks_success() throws Exception {
+        // given
+        String keyword = savedBookEntity.getTitle();
+
+        // when & then
+        mockMvc.perform(get("/api/search/books")
+                        .param("keyword", keyword)
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.searchQuery").value(keyword))
+                .andExpect(jsonPath("$.pageInfo.totalElements").value(1))
+                .andExpect(jsonPath("$.books[0].isbn").value(savedBookEntity.getIsbn()))
+                .andExpect(jsonPath("$.searchMetaData.strategy").value("NONE"))
+                .andExpect(jsonPath("$.searchMetaData.executionTime").isNumber());
+    }
+
+    @Test
+    @DisplayName("[FAILURE] 키워드가 누락된 경우, 400 Bad Request를 반환한다")
+    void searchBooks_keywordMissing_badRequest() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/search/books")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/org/example/booksearchservice/search/service/SearchQueryParserTest.java
+++ b/src/test/java/org/example/booksearchservice/search/service/SearchQueryParserTest.java
@@ -1,0 +1,39 @@
+package org.example.booksearchservice.search.service;
+
+import org.example.booksearchservice.search.application.service.SearchQueryParser;
+import org.example.booksearchservice.search.exception.InvalidSearchQueryException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.example.booksearchservice.common.exception.ErrorCode.INVALID_KEYWORD_COUNT;
+import static org.example.booksearchservice.common.exception.ErrorCode.UNSUPPORTED_OPERATOR;
+
+class SearchQueryParserTest {
+
+    private final SearchQueryParser searchQueryParser = new SearchQueryParser();
+
+    @Test
+    @DisplayName("[ERROR] 지원하지 않는 연산자를 사용한 복합 쿼리는 예외를 발생시킨다")
+    void parse_givenUnsupportedOperator_throwsException() {
+        // given
+        String invalidQuery = "java&spring";
+
+        // when & then
+        assertThatThrownBy(() -> searchQueryParser.parse(invalidQuery))
+                .isInstanceOf(InvalidSearchQueryException.class)
+                .hasMessageContaining(UNSUPPORTED_OPERATOR.getMessage());
+    }
+
+    @Test
+    @DisplayName("[ERROR] 키워드가 비어 있는 복합 쿼리는 예외를 발생시킨다")
+    void parse_givenEmptyKeyword_throwsException() {
+        // given
+        String query = "java|";
+
+        // when & then
+        assertThatThrownBy(() -> searchQueryParser.parse(query))
+                .isInstanceOf(InvalidSearchQueryException.class)
+                .hasMessageContaining(INVALID_KEYWORD_COUNT.getMessage());
+    }
+}

--- a/src/test/java/org/example/booksearchservice/search/service/SearchServiceTest.java
+++ b/src/test/java/org/example/booksearchservice/search/service/SearchServiceTest.java
@@ -1,0 +1,62 @@
+package org.example.booksearchservice.search.service;
+
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.example.booksearchservice.book.domain.Book;
+import org.example.booksearchservice.search.application.dto.SearchResponse;
+import org.example.booksearchservice.search.application.service.SearchService;
+import org.example.booksearchservice.search.application.usecase.KeywordSearchUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.example.booksearchservice.fixture.BookFixture.createBook;
+import static org.example.booksearchservice.search.domain.SearchOperator.NONE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SearchServiceTest {
+
+    private KeywordSearchUseCase keywordSearchUseCase;
+    private SearchService searchService;
+
+    @BeforeEach
+    void setUp() {
+        keywordSearchUseCase = mock(KeywordSearchUseCase.class);
+        searchService = new SearchService(keywordSearchUseCase);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 키워드로 책을 검색하면 메타데이터가 포함된 검색 결과를 반환한다")
+    void searchBooksByKeyword_returnsSearchResponse() {
+        // given
+        String keyword = "java";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        List<Book> books = List.of(createBook());
+        Page<Book> bookPage = new PageImpl<>(books, pageable, books.size());
+        BookPageResponse bookPageResponse = BookPageResponse.of(bookPage);
+
+        when(keywordSearchUseCase.execute(keyword, pageable)).thenReturn(bookPageResponse);
+
+        // when
+        SearchResponse response = searchService.searchBooksByKeyword(keyword, pageable);
+
+        // then
+        AssertionsForClassTypes.assertThat(
+                response.books().stream()
+                        .anyMatch(book ->
+                                book.title().toLowerCase().contains(keyword) ||
+                                        book.subtitle().toLowerCase().contains(keyword))
+        ).isTrue();
+        assertThat(response.searchMetaData().strategy()).isEqualTo(NONE);
+        assertThat(response.searchQuery()).isEqualTo(keyword);
+    }
+}

--- a/src/test/java/org/example/booksearchservice/search/service/SearchServiceTest.java
+++ b/src/test/java/org/example/booksearchservice/search/service/SearchServiceTest.java
@@ -4,8 +4,12 @@ import org.assertj.core.api.AssertionsForClassTypes;
 import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.book.domain.Book;
 import org.example.booksearchservice.search.application.dto.SearchResponse;
+import org.example.booksearchservice.search.application.service.SearchQueryParser;
 import org.example.booksearchservice.search.application.service.SearchService;
 import org.example.booksearchservice.search.application.usecase.KeywordSearchUseCase;
+import org.example.booksearchservice.search.application.usecase.OperatorSearchUseCase;
+import org.example.booksearchservice.search.domain.SearchOperator;
+import org.example.booksearchservice.search.domain.SearchQuery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +19,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.example.booksearchservice.fixture.BookFixture.createBook;
@@ -25,12 +30,18 @@ import static org.mockito.Mockito.when;
 public class SearchServiceTest {
 
     private KeywordSearchUseCase keywordSearchUseCase;
+    private Map<String, OperatorSearchUseCase> operatorSearchUseCaseMap;
+    private SearchQueryParser searchQueryParser;
     private SearchService searchService;
 
     @BeforeEach
     void setUp() {
         keywordSearchUseCase = mock(KeywordSearchUseCase.class);
-        searchService = new SearchService(keywordSearchUseCase);
+        operatorSearchUseCaseMap = Map.of(
+                NONE.name(), mock(OperatorSearchUseCase.class)
+        );
+        searchQueryParser = mock(SearchQueryParser.class);
+        searchService = new SearchService(keywordSearchUseCase, operatorSearchUseCaseMap, searchQueryParser);
     }
 
     @Test
@@ -58,5 +69,40 @@ public class SearchServiceTest {
         ).isTrue();
         assertThat(response.searchMetaData().strategy()).isEqualTo(NONE);
         assertThat(response.searchQuery()).isEqualTo(keyword);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 복합 쿼리로 책을 검색하면 연산자 전략과 함께 검색 결과를 반환한다")
+    void searchBooksByComplexQuery_returnsSearchResponseWithOperator() {
+        // given
+        String query = "java|spring";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        SearchOperator operator = SearchOperator.OR;
+        SearchQuery searchQuery = SearchQuery.builder()
+                .firstKeyword("java")
+                .secondKeyword("spring")
+                .operator(operator)
+                .build();
+
+        List<Book> books = List.of(createBook());
+        Page<Book> bookPage = new PageImpl<>(books, pageable, books.size());
+        BookPageResponse bookPageResponse = BookPageResponse.of(bookPage);
+
+        OperatorSearchUseCase operatorSearchUseCase = mock(OperatorSearchUseCase.class);
+        operatorSearchUseCaseMap = Map.of(operator.name(), operatorSearchUseCase);
+
+        searchService = new SearchService(keywordSearchUseCase, operatorSearchUseCaseMap, searchQueryParser);
+
+        when(searchQueryParser.parse(query)).thenReturn(searchQuery);
+        when(operatorSearchUseCase.execute("java", "spring", pageable)).thenReturn(bookPageResponse);
+
+        // when
+        SearchResponse response = searchService.searchBooksByComplexQuery(query, pageable);
+
+        // then
+        assertThat(response.books()).hasSize(1);
+        assertThat(response.searchQuery()).isEqualTo(query);
+        assertThat(response.searchMetaData().strategy()).isEqualTo(operator);
     }
 }

--- a/src/test/java/org/example/booksearchservice/search/usecase/KeywordSearchUseCaseTest.java
+++ b/src/test/java/org/example/booksearchservice/search/usecase/KeywordSearchUseCaseTest.java
@@ -1,0 +1,43 @@
+package org.example.booksearchservice.search.usecase;
+
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.example.booksearchservice.mock.FakeBookInternalAdapter;
+import org.example.booksearchservice.search.application.port.BookInternalPort;
+import org.example.booksearchservice.search.application.usecase.KeywordSearchUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+public class KeywordSearchUseCaseTest {
+
+    private KeywordSearchUseCase keywordSearchUseCase;
+
+    @BeforeEach
+    void setUp() {
+        BookInternalPort bookInternalPort = new FakeBookInternalAdapter();
+        keywordSearchUseCase = new KeywordSearchUseCase(bookInternalPort);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 키워드로 책을 검색하면 페이징된 책 목록을 반환한다")
+    void execute_givenValidKeyword_returnsBookPageResponse() {
+        // given
+        String keyword = "java";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        BookPageResponse response = keywordSearchUseCase.execute(keyword, pageable);
+
+        // then
+        assertThat(
+                response.books().stream()
+                        .anyMatch(book ->
+                                book.title().toLowerCase().contains(keyword) ||
+                                book.subtitle().toLowerCase().contains(keyword))
+        ).isTrue();
+    }
+}

--- a/src/test/java/org/example/booksearchservice/search/usecase/OrSearchUseCaseTest.java
+++ b/src/test/java/org/example/booksearchservice/search/usecase/OrSearchUseCaseTest.java
@@ -1,0 +1,47 @@
+package org.example.booksearchservice.search.usecase;
+
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.example.booksearchservice.mock.FakeBookInternalAdapter;
+import org.example.booksearchservice.search.application.port.BookInternalPort;
+import org.example.booksearchservice.search.application.usecase.OrSearchUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OrSearchUseCaseTest {
+
+    private OrSearchUseCase orSearchUseCase;
+
+    @BeforeEach
+    void setUp() {
+        BookInternalPort bookInternalPort = new FakeBookInternalAdapter();
+        orSearchUseCase = new OrSearchUseCase(bookInternalPort);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] OR 연산자로 두 키워드 중 하나라도 포함하는 책을 조회한다")
+    void execute_givenTwoKeywords_returnsBooksMatchingEitherKeyword() {
+        // given
+        String firstKeyword = "java";
+        String secondKeyword = "spring";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        BookPageResponse response = orSearchUseCase.execute(firstKeyword, secondKeyword, pageable);
+
+        // then
+        assertThat(response.pageInfo().totalElements()).isEqualTo(3);
+        assertThat(response.books().stream()
+                .anyMatch(book ->
+                        book.title().toLowerCase().contains(firstKeyword) ||
+                                book.subtitle().toLowerCase().contains(firstKeyword) ||
+                                book.title().toLowerCase().contains(secondKeyword) ||
+                                book.subtitle().toLowerCase().contains(secondKeyword)))
+                .isTrue();
+    }
+
+}


### PR DESCRIPTION
## 개요

도서 검색 서비스에 복합 키워드 검색 기능을 추가했습니다. OR 연산자를 지원하여 다중 키워드 검색을 가능하게 하고, 검색 쿼리 파싱과 예외 처리를 구현했습니다.

## 주요 변경사항

* 042aade42205348c4f2c3249ce042f345c8fa5f5, 82307d1dc6165dfa43388a2879d749e005efacaf: 복합 키워드 검색 쿼리를 처리하기 위한 `SearchQuery` 값 객체 및 쿼리 파싱기(`SearchQueryParser`) 구현
* 03c5bcf0df141ded9e1ec5137c60df8f47a5b235, ee0fb1ff709d1897fd587cda5a52978eb721d956, a304c5a3d4aabcd0e778d07448a6685d95b92661: 연산자 기반 검색 유스케이스 인터페이스(`OperatorSearchUseCase`) 및 OR 연산자 구현체(`OrSearchUseCase`), 내부 포트(`BookInternalPort`) 확장 및 어댑터(`BookInternalAdapter`) 구현
* a1335e53b736ddf46eec9c356edb4c6680961194, 2fcdd31e3ed7db77d9e28cba0e6f484c58891527: 복합 키워드 검색 로직을 처리하는 서비스 계층(`SearchService`) 및 복합 검색 API(`SearchController`) 기능 구현
* 3bc6ceea9b96de0c4e566a3555b7f5c3261ca9dd: 지원하지 않는 연산자 및 잘못된 키워드 수에 대한 예외 처리(`InvalidSearchQueryException`) 및 에러 코드 정의
* 1e84815cebf53eb7c13ddd17d1d568796b280716, 5c3b6163793594c7718f3d22e85888040a42cfa9, 66707eac4fa864dc502d734111af9ba36ba3c318: 복합 키워드 검색 도메인/유스케이스/서비스 단위 테스트 및 컨트롤러 통합 테스트 작성

## 테스트 체크리스트

* [x] OR 연산자를 포함한 복합 키워드 검색 정상 수행
* [x] 연산자 미지원 시 예외 발생 확인
* [x] 키워드 개수 미달 또는 초과 시 예외 발생 및 API 응답 검증
* [x] 복합 검색 API 통합 테스트 정상 수행

## 테스트 결과 요약

* 모든 복합 키워드 검색 관련 테스트가 성공적으로 통과했습니다.
* OR 연산자를 포함한 검색 쿼리가 정상적으로 파싱되고, 도서 목록이 올바르게 조회됨을 확인했습니다.
* 예외 상황 발생 시 적절한 예외 처리와 HTTP 응답 반환을 검증했습니다.
