### PR TITLE
feat: 복합 검색에 NOT 연산자(-) 기반 키워드 제외 검색 기능 구현

### DIFF
--- a/src/main/java/org/example/booksearchservice/book/application/port/LoadBookPort.java
+++ b/src/main/java/org/example/booksearchservice/book/application/port/LoadBookPort.java
@@ -10,4 +10,5 @@ public interface LoadBookPort {
     Optional<Book> loadById(Long id);
     Page<Book> loadByKeyword(String keyword, Pageable pageable);
     Page<Book> loadByAnyKeywords(String firstKeyword, String secondKeyword, Pageable pageable);
+    Page<Book> loadByKeywordExcluding(String firstKeyword, String secondKeyword, Pageable pageable);
 }

--- a/src/main/java/org/example/booksearchservice/book/application/service/BookQueryService.java
+++ b/src/main/java/org/example/booksearchservice/book/application/service/BookQueryService.java
@@ -5,6 +5,7 @@ import org.example.booksearchservice.book.application.dto.BookDetailResponse;
 import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.book.application.usecase.LoadBookDetailUseCase;
 import org.example.booksearchservice.book.application.usecase.LoadBooksByAnyKeywordUseCase;
+import org.example.booksearchservice.book.application.usecase.LoadBooksByKeywordExcludingUseCase;
 import org.example.booksearchservice.book.application.usecase.LoadBooksByKeywordUseCase;
 import org.example.booksearchservice.book.domain.Book;
 import org.springframework.data.domain.Page;
@@ -18,6 +19,7 @@ public class BookQueryService {
     private final LoadBookDetailUseCase loadBookDetailUseCase;
     private final LoadBooksByKeywordUseCase loadBooksByKeywordUseCase;
     private final LoadBooksByAnyKeywordUseCase loadBooksByAnyKeywordUseCase;
+    private final LoadBooksByKeywordExcludingUseCase loadBooksByKeywordExcludingUseCase;
 
     public BookDetailResponse getBookDetail(Long id) {
         Book book = loadBookDetailUseCase.execute(id);
@@ -31,6 +33,11 @@ public class BookQueryService {
 
     public BookPageResponse findBooksByAnyKeyword(String firstKeyword, String secondKeyword, Pageable pageable) {
         Page<Book> bookPage = loadBooksByAnyKeywordUseCase.execute(firstKeyword, secondKeyword, pageable);
+        return BookPageResponse.of(bookPage);
+    }
+
+    public BookPageResponse findBooksByKeywordExcluding(String firstKeyword, String secondKeyword, Pageable pageable) {
+        Page<Book> bookPage = loadBooksByKeywordExcludingUseCase.execute(firstKeyword, secondKeyword, pageable);
         return BookPageResponse.of(bookPage);
     }
 }

--- a/src/main/java/org/example/booksearchservice/book/application/usecase/LoadBooksByKeywordExcludingUseCase.java
+++ b/src/main/java/org/example/booksearchservice/book/application/usecase/LoadBooksByKeywordExcludingUseCase.java
@@ -1,0 +1,23 @@
+package org.example.booksearchservice.book.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.booksearchservice.book.application.port.LoadBookPort;
+import org.example.booksearchservice.book.domain.Book;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LoadBooksByKeywordExcludingUseCase {
+
+    private final LoadBookPort loadBookPort;
+
+    public Page<Book> execute(String firstKeyword, String secondKeyword, Pageable pageable) {
+        log.info("Loading books with firstKeyword: [{}], excluding secondKeyword: [{}], page: [{}], size: [{}]",
+                firstKeyword, secondKeyword, pageable.getPageNumber(), pageable.getPageSize());
+        return loadBookPort.loadByKeywordExcluding(firstKeyword, secondKeyword, pageable);
+    }
+}

--- a/src/main/java/org/example/booksearchservice/book/infrastructure/persistence/BookJpaRepository.java
+++ b/src/main/java/org/example/booksearchservice/book/infrastructure/persistence/BookJpaRepository.java
@@ -24,4 +24,14 @@ public interface BookJpaRepository extends JpaRepository<BookEntity, Long> {
                OR LOWER(b.subtitle) LIKE LOWER(CONCAT('%', :secondKeyword, '%')))
             """)
     Page<BookEntity> findByAnyKeywords(String firstKeyword, String secondKeyword, Pageable pageable);
+
+    @Query("""
+            SELECT b
+            FROM BookEntity b
+            WHERE (LOWER(b.title) LIKE LOWER(CONCAT('%', :firstKeyword, '%'))
+                OR LOWER(b.subtitle) LIKE LOWER(CONCAT('%', :firstKeyword, '%')))
+              AND (LOWER(b.title) NOT LIKE LOWER(CONCAT('%', :secondKeyword, '%'))
+                AND LOWER(b.subtitle) NOT LIKE LOWER(CONCAT('%', :secondKeyword, '%')))
+            """)
+    Page<BookEntity> findByKeywordExcluding(String firstKeyword, String secondKeyword, Pageable pageable);
 }

--- a/src/main/java/org/example/booksearchservice/book/infrastructure/persistence/LoadBookAdapter.java
+++ b/src/main/java/org/example/booksearchservice/book/infrastructure/persistence/LoadBookAdapter.java
@@ -32,4 +32,10 @@ public class LoadBookAdapter implements LoadBookPort {
         return bookJpaRepository.findByAnyKeywords(firstKeyword, secondKeyword, pageable)
                 .map(BookEntity::toDomain);
     }
+
+    @Override
+    public Page<Book> loadByKeywordExcluding(String firstKeyword, String secondKeyword, Pageable pageable) {
+        return bookJpaRepository.findByKeywordExcluding(firstKeyword, secondKeyword, pageable)
+                .map(BookEntity::toDomain);
+    }
 }

--- a/src/main/java/org/example/booksearchservice/search/application/port/BookInternalPort.java
+++ b/src/main/java/org/example/booksearchservice/search/application/port/BookInternalPort.java
@@ -6,4 +6,5 @@ import org.springframework.data.domain.Pageable;
 public interface BookInternalPort {
     BookPageResponse findBooksByKeyword(String keyword, Pageable pageable);
     BookPageResponse findBooksByAnyKeyword(String firstKeyword, String secondKeyword, Pageable pageable);
+    BookPageResponse findBooksByKeywordExcluding(String firstKeyword, String secondKeyword, Pageable pageable);
 }

--- a/src/main/java/org/example/booksearchservice/search/application/service/SearchQueryParser.java
+++ b/src/main/java/org/example/booksearchservice/search/application/service/SearchQueryParser.java
@@ -8,8 +8,8 @@ import org.springframework.stereotype.Component;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.example.booksearchservice.common.exception.ErrorCode.*;
-import static org.example.booksearchservice.search.domain.SearchOperator.OR;
+import static org.example.booksearchservice.common.exception.ErrorCode.INVALID_KEYWORD_COUNT;
+import static org.example.booksearchservice.common.exception.ErrorCode.UNSUPPORTED_OPERATOR;
 
 @Component
 public class SearchQueryParser {
@@ -22,10 +22,8 @@ public class SearchQueryParser {
     }
 
     private SearchOperator extractOperator(String query) {
-        if (query.contains(OR.getQuerySymbol())) {
-            return OR;
-        }
-        throw new InvalidSearchQueryException(UNSUPPORTED_OPERATOR);
+        return SearchOperator.fromQuery(query)
+                .orElseThrow(() -> new InvalidSearchQueryException(UNSUPPORTED_OPERATOR));
     }
 
     private List<String> extractKeywords(String query, SearchOperator operator) {

--- a/src/main/java/org/example/booksearchservice/search/application/usecase/NotSearchUseCase.java
+++ b/src/main/java/org/example/booksearchservice/search/application/usecase/NotSearchUseCase.java
@@ -1,0 +1,23 @@
+package org.example.booksearchservice.search.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.example.booksearchservice.search.application.port.BookInternalPort;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service("NOT")
+@RequiredArgsConstructor
+public class NotSearchUseCase implements OperatorSearchUseCase {
+
+    private final BookInternalPort bookInternalPort;
+
+    @Override
+    public BookPageResponse execute(String firstKeyword, String secondKeyword, Pageable pageable) {
+        log.info("Executing NOT search with firstKeyword: [{}], excluding secondKeyword: [{}]",
+                firstKeyword, secondKeyword);
+        return bookInternalPort.findBooksByKeywordExcluding(firstKeyword, secondKeyword, pageable);
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/domain/SearchOperator.java
+++ b/src/main/java/org/example/booksearchservice/search/domain/SearchOperator.java
@@ -3,6 +3,9 @@ package org.example.booksearchservice.search.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
+import java.util.Optional;
+
 @Getter
 @RequiredArgsConstructor
 public enum SearchOperator {
@@ -12,4 +15,11 @@ public enum SearchOperator {
 
     private final String querySymbol;
     private final String splitRegex;
+
+    public static Optional<SearchOperator> fromQuery(String query) {
+        return Arrays.stream(values())
+                .filter(op -> !op.equals(NONE) && query.contains(op.querySymbol))
+                .findFirst();
+    }
 }
+

--- a/src/main/java/org/example/booksearchservice/search/infrastructure/internal/BookInternalAdapter.java
+++ b/src/main/java/org/example/booksearchservice/search/infrastructure/internal/BookInternalAdapter.java
@@ -22,4 +22,9 @@ public class BookInternalAdapter implements BookInternalPort {
     public BookPageResponse findBooksByAnyKeyword(String firstKeyword, String secondKeyword, Pageable pageable) {
         return bookQueryService.findBooksByAnyKeyword(firstKeyword, secondKeyword, pageable);
     }
+
+    @Override
+    public BookPageResponse findBooksByKeywordExcluding(String firstKeyword, String secondKeyword, Pageable pageable) {
+        return bookQueryService.findBooksByKeywordExcluding(firstKeyword, secondKeyword, pageable);
+    }
 }

--- a/src/test/java/org/example/booksearchservice/book/application/service/BookQueryServiceTest.java
+++ b/src/test/java/org/example/booksearchservice/book/application/service/BookQueryServiceTest.java
@@ -4,6 +4,7 @@ import org.example.booksearchservice.book.application.dto.BookDetailResponse;
 import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.book.application.usecase.LoadBookDetailUseCase;
 import org.example.booksearchservice.book.application.usecase.LoadBooksByAnyKeywordUseCase;
+import org.example.booksearchservice.book.application.usecase.LoadBooksByKeywordExcludingUseCase;
 import org.example.booksearchservice.book.application.usecase.LoadBooksByKeywordUseCase;
 import org.example.booksearchservice.book.domain.Book;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +19,7 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.example.booksearchservice.fixture.BookFixture.createBook;
+import static org.example.booksearchservice.fixture.BookFixture.createBooks;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -26,6 +28,7 @@ class BookQueryServiceTest {
     private LoadBookDetailUseCase loadBookUseCase;
     private LoadBooksByKeywordUseCase loadBooksByKeywordUseCase;
     private LoadBooksByAnyKeywordUseCase loadBooksByAnyKeywordUseCase;
+    private LoadBooksByKeywordExcludingUseCase loadBooksByKeywordExcludingUseCase;
     private BookQueryService bookQueryService;
 
     @BeforeEach
@@ -33,7 +36,8 @@ class BookQueryServiceTest {
         loadBookUseCase = mock(LoadBookDetailUseCase.class);
         loadBooksByKeywordUseCase = mock(LoadBooksByKeywordUseCase.class);
         loadBooksByAnyKeywordUseCase = mock(LoadBooksByAnyKeywordUseCase.class);
-        bookQueryService = new BookQueryService(loadBookUseCase, loadBooksByKeywordUseCase, loadBooksByAnyKeywordUseCase);
+        loadBooksByKeywordExcludingUseCase = mock(LoadBooksByKeywordExcludingUseCase.class);
+        bookQueryService = new BookQueryService(loadBookUseCase, loadBooksByKeywordUseCase, loadBooksByAnyKeywordUseCase, loadBooksByKeywordExcludingUseCase);
     }
 
     @Test
@@ -72,22 +76,68 @@ class BookQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[SUCCESS] 두 개의 키워드와 페이징 정보로 책 목록을 조회하면 페이지 응답을 반환한다")
-    void findBooksByAnyKeyword_givenTwoKeywordsAndPageable_returnsBookPageResponse() {
+    @DisplayName("[SUCCESS] 두 개의 키워드와 페이징 정보로 책 목록을 조회하면 페이지 응답을 반환하고, 적어도 하나의 키워드를 포함한다")
+    void findBooksByAnyKeyword_givenTwoKeywordsAndPageable_returnsBookPageResponseContainingAnyKeyword() {
         // given
         String firstKeyword = "java";
         String secondKeyword = "spring";
         Pageable pageable = PageRequest.of(0, 10);
 
-        List<Book> books = List.of(createBook());
-        Page<Book> bookPage = new PageImpl<>(books, pageable, books.size());
+        // 책 생성 후, firstKeyword 또는 secondKeyword 포함하는 책만 필터링
+        List<Book> books = createBooks(5).stream()
+                .filter(book -> {
+                    String title = book.getBasicInfo().getTitle().toLowerCase();
+                    String subtitle = book.getBasicInfo().getSubtitle().toLowerCase();
+                    return title.contains(firstKeyword) || subtitle.contains(firstKeyword) ||
+                            title.contains(secondKeyword) || subtitle.contains(secondKeyword);
+                })
+                .toList();
 
+        Page<Book> bookPage = new PageImpl<>(books, pageable, books.size());
         when(loadBooksByAnyKeywordUseCase.execute(firstKeyword, secondKeyword, pageable)).thenReturn(bookPage);
 
         // when
         BookPageResponse response = bookQueryService.findBooksByAnyKeyword(firstKeyword, secondKeyword, pageable);
 
         // then
-        assertThat(response.books().getFirst().isbn()).isEqualTo(books.getFirst().getIsbn());
+        response.books().forEach(bookDto -> {
+            String title = bookDto.title().toLowerCase();
+            String subtitle = bookDto.subtitle().toLowerCase();
+            boolean containsAnyKeyword = title.contains(firstKeyword) || subtitle.contains(firstKeyword) ||
+                    title.contains(secondKeyword) || subtitle.contains(secondKeyword);
+
+            assertThat(containsAnyKeyword).isTrue();
+        });
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 첫 번째 키워드를 포함하고 두 번째 키워드를 제외한 책 목록 조회 시 페이지 응답을 반환하고, 두 번째 키워드가 포함된 책은 없다")
+    void findBooksByKeywordExcluding_givenTwoKeywordsAndPageable_returnsBookPageResponseWithoutSecondKeyword() {
+        // given
+        String firstKeyword = "spring";
+        String secondKeyword = "java";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // 책 5권 생성 후, 첫 번째 키워드 포함 && 두 번째 키워드 미포함 조건을 만족하는 책만 필터링
+        List<Book> books = createBooks(5).stream()
+                .filter(book -> {
+                    String title = book.getBasicInfo().getTitle().toLowerCase();
+                    String subtitle = book.getBasicInfo().getSubtitle().toLowerCase();
+                    return (title.contains(firstKeyword) || subtitle.contains(firstKeyword)) &&
+                            !(title.contains(secondKeyword) || subtitle.contains(secondKeyword));
+                })
+                .toList();
+
+        Page<Book> bookPage = new PageImpl<>(books, pageable, books.size());
+        when(loadBooksByKeywordExcludingUseCase.execute(firstKeyword, secondKeyword, pageable)).thenReturn(bookPage);
+
+        // when
+        BookPageResponse response = bookQueryService.findBooksByKeywordExcluding(firstKeyword, secondKeyword, pageable);
+
+        // then
+        response.books().forEach(bookDto -> {
+            assertThat(bookDto.title().toLowerCase()).doesNotContain(secondKeyword.toLowerCase());
+            assertThat(bookDto.subtitle().toLowerCase()).doesNotContain(secondKeyword.toLowerCase());
+        });
     }
 }

--- a/src/test/java/org/example/booksearchservice/book/application/usecase/LoadBooksByKeywordExcludingUseCaseTest.java
+++ b/src/test/java/org/example/booksearchservice/book/application/usecase/LoadBooksByKeywordExcludingUseCaseTest.java
@@ -1,0 +1,44 @@
+package org.example.booksearchservice.book.application.usecase;
+
+import org.example.booksearchservice.book.domain.Book;
+import org.example.booksearchservice.mock.FakeLoadBookAdapter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Page;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LoadBooksByKeywordExcludingUseCaseTest {
+
+    private LoadBooksByKeywordExcludingUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        FakeLoadBookAdapter fakeLoadBookAdapter = new FakeLoadBookAdapter();
+        useCase = new LoadBooksByKeywordExcludingUseCase(fakeLoadBookAdapter);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 첫 번째 키워드는 포함하고 두 번째 키워드는 제외하는 책 목록 조회")
+    void execute_givenKeywords_returnsBooksExcludingSecondKeyword() {
+        // given
+        String firstKeyword = "java";
+        String secondKeyword = "spring";
+        PageRequest pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<Book> result = useCase.execute(firstKeyword, secondKeyword, pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).allMatch(book ->
+                (book.getBasicInfo().getTitle().toLowerCase().contains(firstKeyword.toLowerCase())
+                        || book.getBasicInfo().getSubtitle().toLowerCase().contains(firstKeyword.toLowerCase()))
+                        &&
+                        !(book.getBasicInfo().getTitle().toLowerCase().contains(secondKeyword.toLowerCase())
+                                || book.getBasicInfo().getSubtitle().toLowerCase().contains(secondKeyword.toLowerCase()))
+        );
+    }
+}

--- a/src/test/java/org/example/booksearchservice/mock/FakeBookInternalAdapter.java
+++ b/src/test/java/org/example/booksearchservice/mock/FakeBookInternalAdapter.java
@@ -27,6 +27,18 @@ public class FakeBookInternalAdapter implements BookInternalPort {
         return BookPageResponse.of(bookPage);
     }
 
+    @Override
+    public BookPageResponse findBooksByKeywordExcluding(String firstKeyword, String secondKeyword, Pageable pageable) {
+        List<Book> allBooks = createBooks(5);
+        List<Book> filteredBooks = allBooks.stream()
+                .filter(book -> containsKeyword(book, firstKeyword))
+                .filter(book -> !containsKeyword(book, secondKeyword))
+                .toList();
+
+        Page<Book> bookPage = new PageImpl<>(filteredBooks, pageable, filteredBooks.size());
+        return BookPageResponse.of(bookPage);
+    }
+
     private List<Book> filterBooksByKeywords(List<String> keywords) {
         List<Book> allBooks = createBooks(5);
         return allBooks.stream()

--- a/src/test/java/org/example/booksearchservice/mock/FakeLoadBookAdapter.java
+++ b/src/test/java/org/example/booksearchservice/mock/FakeLoadBookAdapter.java
@@ -34,6 +34,7 @@ public class FakeLoadBookAdapter implements LoadBookPort {
                         .publishedDate(LocalDate.of(2018, 1, 11))
                         .build())
                 .build());
+
         store.put(2L, Book.builder()
                 .isbn("978-0-13-468609-7")
                 .basicInfo(BasicInfo.builder()
@@ -56,40 +57,50 @@ public class FakeLoadBookAdapter implements LoadBookPort {
     @Override
     public Page<Book> loadByKeyword(String keyword, Pageable pageable) {
         List<Book> filteredBooks = store.values().stream()
-                .filter(book -> book.getBasicInfo()
-                        .getTitle()
-                        .toLowerCase()
-                        .contains(keyword.toLowerCase()))
+                .filter(book -> containsIgnoreCase(book.getBasicInfo().getTitle(), keyword))
                 .toList();
 
-        int pageOffset = toIntExact(pageable.getOffset());
-        int pageLimit = min((pageOffset + pageable.getPageSize()), filteredBooks.size());
-        List<Book> pagedBooks = (pageOffset <= pageLimit)
-                ? filteredBooks.subList(pageOffset, pageLimit)
-                : List.of();
-
-        return new PageImpl<>(pagedBooks, pageable, filteredBooks.size());
+        return paginate(filteredBooks, pageable);
     }
 
     @Override
     public Page<Book> loadByAnyKeywords(String firstKeyword, String secondKeyword, Pageable pageable) {
         List<Book> filteredBooks = store.values().stream()
                 .filter(book -> {
-                    String title = book.getBasicInfo().getTitle().toLowerCase();
-                    String subtitle = book.getBasicInfo().getSubtitle().toLowerCase();
-                    return title.contains(firstKeyword.toLowerCase()) ||
-                            subtitle.contains(firstKeyword.toLowerCase()) ||
-                            title.contains(secondKeyword.toLowerCase()) ||
-                            subtitle.contains(secondKeyword.toLowerCase());
+                    return containsIgnoreCase(book.getBasicInfo().getTitle(), firstKeyword) ||
+                            containsIgnoreCase(book.getBasicInfo().getSubtitle(), firstKeyword) ||
+                            containsIgnoreCase(book.getBasicInfo().getTitle(), secondKeyword) ||
+                            containsIgnoreCase(book.getBasicInfo().getSubtitle(), secondKeyword);
                 })
                 .toList();
 
-        int pageOffset = toIntExact(pageable.getOffset());
-        int pageLimit = min(pageOffset + pageable.getPageSize(), filteredBooks.size());
-        List<Book> pagedBooks = (pageOffset <= pageLimit)
-                ? filteredBooks.subList(pageOffset, pageLimit)
-                : List.of();
+        return paginate(filteredBooks, pageable);
+    }
 
-        return new PageImpl<>(pagedBooks, pageable, filteredBooks.size());
+    @Override
+    public Page<Book> loadByKeywordExcluding(String firstKeyword, String secondKeyword, Pageable pageable) {
+        List<Book> filteredBooks = store.values().stream()
+                .filter(book -> {
+                    boolean containsFirst = containsIgnoreCase(book.getBasicInfo().getTitle(), firstKeyword) ||
+                            containsIgnoreCase(book.getBasicInfo().getSubtitle(), firstKeyword);
+                    boolean containsSecond = containsIgnoreCase(book.getBasicInfo().getTitle(), secondKeyword) ||
+                            containsIgnoreCase(book.getBasicInfo().getSubtitle(), secondKeyword);
+                    return containsFirst && !containsSecond;
+                })
+                .toList();
+
+        return paginate(filteredBooks, pageable);
+    }
+
+    private Page<Book> paginate(List<Book> books, Pageable pageable) {
+        int pageOffset = toIntExact(pageable.getOffset());
+        int pageLimit = min(pageOffset + pageable.getPageSize(), books.size());
+        List<Book> pagedBooks = (pageOffset <= pageLimit) ? books.subList(pageOffset, pageLimit) : List.of();
+        return new PageImpl<>(pagedBooks, pageable, books.size());
+    }
+
+    private boolean containsIgnoreCase(String source, String target) {
+        if (source == null || target == null) return false;
+        return source.toLowerCase().contains(target.toLowerCase());
     }
 }

--- a/src/test/java/org/example/booksearchservice/search/usecase/NotSearchUseCaseTest.java
+++ b/src/test/java/org/example/booksearchservice/search/usecase/NotSearchUseCaseTest.java
@@ -1,0 +1,44 @@
+package org.example.booksearchservice.search.usecase;
+
+import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.example.booksearchservice.mock.FakeBookInternalAdapter;
+import org.example.booksearchservice.search.application.port.BookInternalPort;
+import org.example.booksearchservice.search.application.usecase.NotSearchUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NotSearchUseCaseTest {
+
+    private NotSearchUseCase notSearchUseCase;
+
+    @BeforeEach
+    void setUp() {
+        BookInternalPort bookInternalPort = new FakeBookInternalAdapter();
+        notSearchUseCase = new NotSearchUseCase(bookInternalPort);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] NOT 연산자로 첫 번째 키워드는 포함하고 두 번째 키워드는 제외한 책을 조회한다")
+    void execute_givenTwoKeywords_returnsBooksMatchingFirstKeywordExcludingSecondKeyword() {
+        // given
+        String firstKeyword = "java";
+        String secondKeyword = "effective";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        BookPageResponse response = notSearchUseCase.execute(firstKeyword, secondKeyword, pageable);
+
+        // then
+        assertThat(response.pageInfo().totalElements()).isEqualTo(1);
+        assertThat(response.books())
+                .allMatch(book ->
+                        (book.title().toLowerCase().contains(firstKeyword) || book.subtitle().toLowerCase().contains(firstKeyword)) &&
+                                !book.title().toLowerCase().contains(secondKeyword) && !book.subtitle().toLowerCase().contains(secondKeyword)
+                );
+    }
+}


### PR DESCRIPTION
## 개요

복합 검색 기능에 NOT 연산자(-)를 지원하여 특정 키워드를 제외하는 검색이 가능하도록 기능을 추가합니다.
기존 검색 로직을 확장하고, 이에 따른 예외 처리 및 테스트 코드도 함께 구현합니다.

## 주요 변경사항

* c562fea7856b0a1ec4a0a322454a53111d084690: NOT 연산자 처리용 유스케이스(`NotSearchUseCase`)와 검색 도메인(`SearchOperator`) 확장
* f17faa1f2894143ff277e659b296290d15312f48: JPA Repository에 NOT 연산자 조건을 반영한 쿼리 메서드 추가 (`findByKeywordExcluding`)
* 5ba3175c7e6cd3a66f4c3561c0a7d4550a4a8138: 특정 키워드 제외 도서 조회 유스케이스(`LoadBooksByKeywordExcludingUseCase`), NOT 연산자 기반 복합 검색 서비스 메서드 추가(`BookQueryService`), 제외 키워드 포함 도서 조회 포트 메서드 정의(`LoadBookPort`)에 NOT 연산자 기반 도서 조회 기능 추가
* a24aff792128c74c86c6d3a1edd4c02de2fb0854: NOT 연산자 복합 검색 내부 포트 메서드 구현(`BookInternalAdapter`)
* fb07402b7c79d74ece9f8332a2861be6f4a7d801, eae1b5bd41266a66aee1841219e1e8675c67e524: 단위 테스트 케이스 추가

## 테스트 체크리스트

* [x] NOT 연산자(-) 포함한 검색어 입력 시 제외 키워드가 제대로 반영되는지 확인
* [x] 정상적인 검색 결과 반환
* [x] 예외 케이스(잘못된 NOT 연산자 사용 등) 발생 시 적절한 예외 처리 확인
* [x] 통합 테스트를 통한 API 정상 동작 검증

## 테스트 결과 요약

* 모든 단위 및 통합 테스트가 성공적으로 통과되었습니다.
* NOT 연산자 포함 검색어 입력 시 제외 키워드가 정확히 반영되어 검색 결과가 필터링됨을 확인했습니다.
* 예외 상황에서도 안정적으로 예외가 처리되고 적절한 에러 응답이 반환됨을 검증했습니다.