### PR TITLE
feat: 인기 검색어 집계 및 조회 기능 구현

### DIFF
--- a/src/main/java/org/example/booksearchservice/common/config/AsyncConfig.java
+++ b/src/main/java/org/example/booksearchservice/common/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package org.example.booksearchservice.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/org/example/booksearchservice/search/application/dto/PopularKeywordResponse.java
+++ b/src/main/java/org/example/booksearchservice/search/application/dto/PopularKeywordResponse.java
@@ -1,0 +1,11 @@
+package org.example.booksearchservice.search.application.dto;
+
+import java.util.List;
+
+public record PopularKeywordResponse(
+        List<String> keywords
+) {
+    public static PopularKeywordResponse of(List<String> keywords) {
+        return new PopularKeywordResponse(keywords);
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/application/port/LoadPopularKeywordPort.java
+++ b/src/main/java/org/example/booksearchservice/search/application/port/LoadPopularKeywordPort.java
@@ -1,0 +1,7 @@
+package org.example.booksearchservice.search.application.port;
+
+import java.util.List;
+
+public interface LoadPopularKeywordPort {
+    List<String> findTop10Keywords();
+}

--- a/src/main/java/org/example/booksearchservice/search/application/port/UpdatePopularKeywordPort.java
+++ b/src/main/java/org/example/booksearchservice/search/application/port/UpdatePopularKeywordPort.java
@@ -1,0 +1,5 @@
+package org.example.booksearchservice.search.application.port;
+
+public interface UpdatePopularKeywordPort {
+    void incrementCount(String keyword);
+}

--- a/src/main/java/org/example/booksearchservice/search/application/service/PopularKeywordService.java
+++ b/src/main/java/org/example/booksearchservice/search/application/service/PopularKeywordService.java
@@ -1,0 +1,20 @@
+package org.example.booksearchservice.search.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.booksearchservice.search.application.dto.PopularKeywordResponse;
+import org.example.booksearchservice.search.application.usecase.LoadPopularKeywordUseCase;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PopularKeywordService {
+
+    private final LoadPopularKeywordUseCase loadPopularKeywordUseCase;
+
+    public PopularKeywordResponse getPopularKeywords() {
+        List<String> keywords = loadPopularKeywordUseCase.execute();
+        return PopularKeywordResponse.of(keywords);
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/application/service/SearchService.java
+++ b/src/main/java/org/example/booksearchservice/search/application/service/SearchService.java
@@ -6,6 +6,7 @@ import org.example.booksearchservice.search.application.dto.SearchMetaData;
 import org.example.booksearchservice.search.application.dto.SearchResponse;
 import org.example.booksearchservice.search.application.usecase.OperatorSearchUseCase;
 import org.example.booksearchservice.search.application.usecase.KeywordSearchUseCase;
+import org.example.booksearchservice.search.application.usecase.UpdatePopularKeywordUseCase;
 import org.example.booksearchservice.search.domain.SearchOperator;
 import org.example.booksearchservice.search.domain.SearchQuery;
 import org.springframework.data.domain.Pageable;
@@ -23,8 +24,11 @@ public class SearchService {
     private final Map<String, OperatorSearchUseCase> operatorSearchUseCaseMap;
     private final SearchQueryParser searchQueryParser;
 
+    private final UpdatePopularKeywordUseCase updatePopularKeywordUseCase;
+
     public SearchResponse searchBooksByKeyword(String keyword, Pageable pageable) {
         BookPageResponse bookPageResponse = keywordSearchUseCase.execute(keyword, pageable);
+        updatePopularKeywordUseCase.execute(keyword);
         return buildSearchResponse(keyword, bookPageResponse, NONE);
     }
 
@@ -38,6 +42,8 @@ public class SearchService {
                 searchQuery.getSecondKeyword(),
                 pageable
         );
+
+        updatePopularKeywordUseCase.execute(searchQuery.getFirstKeyword());
 
         return buildSearchResponse(query, bookPageResponse, searchOperator);
     }

--- a/src/main/java/org/example/booksearchservice/search/application/usecase/LoadPopularKeywordUseCase.java
+++ b/src/main/java/org/example/booksearchservice/search/application/usecase/LoadPopularKeywordUseCase.java
@@ -1,0 +1,21 @@
+package org.example.booksearchservice.search.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.booksearchservice.search.application.port.LoadPopularKeywordPort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LoadPopularKeywordUseCase {
+
+    private final LoadPopularKeywordPort loadPopularKeywordPort;
+
+    public List<String> execute() {
+        log.info("Executing load of top 10 popular keywords");
+        return loadPopularKeywordPort.findTop10Keywords();
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/application/usecase/UpdatePopularKeywordUseCase.java
+++ b/src/main/java/org/example/booksearchservice/search/application/usecase/UpdatePopularKeywordUseCase.java
@@ -1,0 +1,21 @@
+package org.example.booksearchservice.search.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.booksearchservice.search.application.port.UpdatePopularKeywordPort;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UpdatePopularKeywordUseCase {
+
+    private final UpdatePopularKeywordPort updatePopularKeywordPort;
+
+    @Async
+    public void execute(String keyword) {
+        log.info("Executing increment of popular keyword: [{}]", keyword);
+        updatePopularKeywordPort.incrementCount(keyword);
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/infrastructure/cache/InMemoryPopularKeywordAdapter.java
+++ b/src/main/java/org/example/booksearchservice/search/infrastructure/cache/InMemoryPopularKeywordAdapter.java
@@ -1,0 +1,32 @@
+package org.example.booksearchservice.search.infrastructure.cache;
+
+import org.example.booksearchservice.search.application.port.LoadPopularKeywordPort;
+import org.example.booksearchservice.search.application.port.UpdatePopularKeywordPort;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class InMemoryPopularKeywordAdapter implements LoadPopularKeywordPort, UpdatePopularKeywordPort {
+
+    private static final int TOP_KEYWORD_LIMIT = 10;
+
+    private final Map<String, Integer> keywordCountMap = new ConcurrentHashMap<>();
+
+    @Override
+    public List<String> findTop10Keywords() {
+        return keywordCountMap.entrySet().stream()
+                .sorted((e1, e2) -> e2.getValue().compareTo(e1.getValue()))
+                .limit(TOP_KEYWORD_LIMIT)
+                .map(Map.Entry::getKey)
+                .toList();
+    }
+
+    @Override
+    public void incrementCount(String keyword) {
+        keywordCountMap.merge(keyword, 1, Integer::sum);
+    }
+}
+

--- a/src/main/java/org/example/booksearchservice/search/presentation/web/PopularKeywordController.java
+++ b/src/main/java/org/example/booksearchservice/search/presentation/web/PopularKeywordController.java
@@ -1,0 +1,23 @@
+package org.example.booksearchservice.search.presentation.web;
+
+import lombok.RequiredArgsConstructor;
+import org.example.booksearchservice.search.application.dto.PopularKeywordResponse;
+import org.example.booksearchservice.search.application.service.PopularKeywordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/search/popular-keywords")
+@RequiredArgsConstructor
+public class PopularKeywordController {
+
+    private final PopularKeywordService popularKeywordService;
+
+    @GetMapping
+    public ResponseEntity<PopularKeywordResponse> getPopularKeywords() {
+        PopularKeywordResponse response = popularKeywordService.getPopularKeywords();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/test/java/org/example/booksearchservice/search/infrastructure/InMemoryPopularKeywordAdapterTest.java
+++ b/src/test/java/org/example/booksearchservice/search/infrastructure/InMemoryPopularKeywordAdapterTest.java
@@ -1,0 +1,50 @@
+package org.example.booksearchservice.search.infrastructure;
+
+import org.example.booksearchservice.search.infrastructure.cache.InMemoryPopularKeywordAdapter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InMemoryPopularKeywordAdapterTest {
+
+    private InMemoryPopularKeywordAdapter inMemoryPopularKeywordAdapter;
+
+    @BeforeEach
+    void setUp() {
+        inMemoryPopularKeywordAdapter = new InMemoryPopularKeywordAdapter();
+    }
+
+    @Test
+    @DisplayName("키워드 카운트가 정상적으로 증가하는지 테스트")
+    void incrementCount_increasesCountCorrectly() {
+        inMemoryPopularKeywordAdapter.incrementCount("java");
+        inMemoryPopularKeywordAdapter.incrementCount("java");
+
+        List<String> topKeywords = inMemoryPopularKeywordAdapter.findTop10Keywords();
+
+        assertEquals(1, topKeywords.size(), "인기 검색어 목록 크기 확인");
+        assertEquals("java", topKeywords.get(0), "최상위 키워드가 'java'인지 확인");
+    }
+
+    @Test
+    @DisplayName("최상위 10개의 키워드가 올바르게 조회되는지 테스트")
+    void findTop10Keywords_returnsTop10() {
+        for (int i = 0; i < 20; i++) {
+            String keyword = "keyword" + i;
+            for (int j = 0; j < i; j++) {
+                inMemoryPopularKeywordAdapter.incrementCount(keyword);
+            }
+        }
+
+        List<String> topKeywords = inMemoryPopularKeywordAdapter.findTop10Keywords();
+
+        assertEquals(10, topKeywords.size(), "최상위 10개 키워드 개수 확인");
+        assertTrue(topKeywords.contains("keyword19"), "최상위 키워드에 keyword19 포함 확인");
+        assertTrue(topKeywords.contains("keyword10"), "최상위 키워드에 keyword10 포함 확인");
+        assertFalse(topKeywords.contains("keyword0"), "최상위 키워드에 keyword0 미포함 확인");
+    }
+}

--- a/src/test/java/org/example/booksearchservice/search/presentation/PopularKeywordControllerTest.java
+++ b/src/test/java/org/example/booksearchservice/search/presentation/PopularKeywordControllerTest.java
@@ -1,0 +1,50 @@
+package org.example.booksearchservice.search.presentation;
+
+import org.example.booksearchservice.search.infrastructure.cache.InMemoryPopularKeywordAdapter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@AutoConfigureMockMvc
+public class PopularKeywordControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private InMemoryPopularKeywordAdapter popularKeywordAdapter;
+
+    @BeforeEach
+    void setUp() {
+        for (int i = 1; i <= 15; i++) {
+            String keyword = "keyword" + i;
+            for (int j = 0; j < i; j++) {  // i만큼 count 증가
+                popularKeywordAdapter.incrementCount(keyword);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 인기 키워드 목록을 10개까지 반환한다")
+    void getPopularKeywords_returnsTop10() throws Exception {
+        mockMvc.perform(get("/api/search/popular-keywords")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.keywords", hasSize(10)))
+                .andExpect(jsonPath("$.keywords[0]", is("keyword15")))
+                .andExpect(jsonPath("$.keywords[9]", is("keyword6")));
+    }
+}

--- a/src/test/java/org/example/booksearchservice/search/service/PopularKeywordServiceTest.java
+++ b/src/test/java/org/example/booksearchservice/search/service/PopularKeywordServiceTest.java
@@ -1,0 +1,42 @@
+package org.example.booksearchservice.search.service;
+
+import org.example.booksearchservice.search.application.dto.PopularKeywordResponse;
+import org.example.booksearchservice.search.application.service.PopularKeywordService;
+import org.example.booksearchservice.search.application.usecase.LoadPopularKeywordUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+public class PopularKeywordServiceTest {
+
+    private LoadPopularKeywordUseCase loadPopularKeywordUseCase;
+    private PopularKeywordService popularKeywordService;
+
+    @BeforeEach
+    void setUp() {
+        loadPopularKeywordUseCase = mock(LoadPopularKeywordUseCase.class);
+        popularKeywordService = new PopularKeywordService(loadPopularKeywordUseCase);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 인기 검색어를 조회하면 키워드 목록을 반환한다")
+
+    void testGetPopularKeywords() {
+        // given
+        List<String> keywords = List.of("java", "spring", "docker");
+        when(loadPopularKeywordUseCase.execute()).thenReturn(keywords);
+
+        // when
+        PopularKeywordResponse response = popularKeywordService.getPopularKeywords();
+
+        // then
+        assertThat(response.keywords()).isEqualTo(keywords);
+        verify(loadPopularKeywordUseCase, times(1)).execute();
+    }
+}

--- a/src/test/java/org/example/booksearchservice/search/service/SearchServiceTest.java
+++ b/src/test/java/org/example/booksearchservice/search/service/SearchServiceTest.java
@@ -8,6 +8,7 @@ import org.example.booksearchservice.search.application.service.SearchQueryParse
 import org.example.booksearchservice.search.application.service.SearchService;
 import org.example.booksearchservice.search.application.usecase.KeywordSearchUseCase;
 import org.example.booksearchservice.search.application.usecase.OperatorSearchUseCase;
+import org.example.booksearchservice.search.application.usecase.UpdatePopularKeywordUseCase;
 import org.example.booksearchservice.search.domain.SearchOperator;
 import org.example.booksearchservice.search.domain.SearchQuery;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,16 +33,27 @@ public class SearchServiceTest {
     private KeywordSearchUseCase keywordSearchUseCase;
     private Map<String, OperatorSearchUseCase> operatorSearchUseCaseMap;
     private SearchQueryParser searchQueryParser;
+    private UpdatePopularKeywordUseCase updatePopularKeywordUseCase;
+
     private SearchService searchService;
+
+    private OperatorSearchUseCase orOperatorSearchUseCase;
 
     @BeforeEach
     void setUp() {
         keywordSearchUseCase = mock(KeywordSearchUseCase.class);
+
+        orOperatorSearchUseCase = mock(OperatorSearchUseCase.class);
+
         operatorSearchUseCaseMap = Map.of(
-                NONE.name(), mock(OperatorSearchUseCase.class)
+                NONE.name(), mock(OperatorSearchUseCase.class),
+                SearchOperator.OR.name(), orOperatorSearchUseCase
         );
+
         searchQueryParser = mock(SearchQueryParser.class);
-        searchService = new SearchService(keywordSearchUseCase, operatorSearchUseCaseMap, searchQueryParser);
+        updatePopularKeywordUseCase = mock(UpdatePopularKeywordUseCase.class);
+
+        searchService = new SearchService(keywordSearchUseCase, operatorSearchUseCaseMap, searchQueryParser, updatePopularKeywordUseCase);
     }
 
     @Test
@@ -89,13 +101,9 @@ public class SearchServiceTest {
         Page<Book> bookPage = new PageImpl<>(books, pageable, books.size());
         BookPageResponse bookPageResponse = BookPageResponse.of(bookPage);
 
-        OperatorSearchUseCase operatorSearchUseCase = mock(OperatorSearchUseCase.class);
-        operatorSearchUseCaseMap = Map.of(operator.name(), operatorSearchUseCase);
-
-        searchService = new SearchService(keywordSearchUseCase, operatorSearchUseCaseMap, searchQueryParser);
-
         when(searchQueryParser.parse(query)).thenReturn(searchQuery);
-        when(operatorSearchUseCase.execute("java", "spring", pageable)).thenReturn(bookPageResponse);
+        when(orOperatorSearchUseCase.execute("java", "spring", pageable))
+                .thenReturn(bookPageResponse);
 
         // when
         SearchResponse response = searchService.searchBooksByComplexQuery(query, pageable);

--- a/src/test/java/org/example/booksearchservice/search/usecase/LoadPopularKeywordUseCaseTest.java
+++ b/src/test/java/org/example/booksearchservice/search/usecase/LoadPopularKeywordUseCaseTest.java
@@ -1,0 +1,38 @@
+package org.example.booksearchservice.search.usecase;
+
+import org.example.booksearchservice.search.application.usecase.LoadPopularKeywordUseCase;
+import org.example.booksearchservice.search.infrastructure.cache.InMemoryPopularKeywordAdapter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LoadPopularKeywordUseCaseTest {
+
+    private LoadPopularKeywordUseCase loadPopularKeywordUseCase;
+
+    @BeforeEach
+    void setUp() {
+        InMemoryPopularKeywordAdapter popularKeywordAdapter = new InMemoryPopularKeywordAdapter();
+        loadPopularKeywordUseCase = new LoadPopularKeywordUseCase(popularKeywordAdapter);
+        for (int i = 1; i <= 15; i++) {
+            String keyword = "keyword" + i;
+            for (int j = 0; j < i; j++) {
+                popularKeywordAdapter.incrementCount(keyword);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 인기 검색어 상위 10개를 반환한다")
+    void testFindTop10Keywords() {
+        List<String> topKeywords = loadPopularKeywordUseCase.execute();
+
+        assertThat(topKeywords).hasSize(10);
+        assertThat(topKeywords.get(0)).isEqualTo("keyword15");
+        assertThat(topKeywords).contains("keyword10");
+    }
+}

--- a/src/test/java/org/example/booksearchservice/search/usecase/UpdatePopularKeywordUseCaseTest.java
+++ b/src/test/java/org/example/booksearchservice/search/usecase/UpdatePopularKeywordUseCaseTest.java
@@ -1,0 +1,35 @@
+package org.example.booksearchservice.search.usecase;
+
+import org.example.booksearchservice.search.application.usecase.UpdatePopularKeywordUseCase;
+import org.example.booksearchservice.search.infrastructure.cache.InMemoryPopularKeywordAdapter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class UpdatePopularKeywordUseCaseTest {
+
+    private InMemoryPopularKeywordAdapter inMemoryAdapter;
+    private UpdatePopularKeywordUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        inMemoryAdapter = new InMemoryPopularKeywordAdapter();
+        useCase = new UpdatePopularKeywordUseCase(inMemoryAdapter);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 인기 검색어 카운트가 증가하는지 확인")
+    void execute_incrementsKeywordCount() {
+        String keyword = "java";
+
+        useCase.execute(keyword);
+
+        List<String> topKeywords = inMemoryAdapter.findTop10Keywords();
+        assertThat(topKeywords.size()).isEqualTo(1);
+    }
+}
+


### PR DESCRIPTION
## 개요

도서 검색 서비스에 인기 검색어 집계 및 조회 기능을 추가합니다.
사용자가 검색한 키워드를 비동기적으로 집계하고, 상위 10개 인기 키워드를 조회할 수 있도록 REST API를 제공합니다.

## 주요 변경사항

* 02c4e8b63f94db6f80d33aabb601604648d72ec6: 인메모리 기반 인기 검색어 집계 어댑터(`InMemoryPopularKeywordAdapter`) 구현
* bc63c836f2ec8d07b211d7cf06c53418bcbbab7f: 인기 검색어 카운트 증가 로직을 비동기 처리(`@Async`)로 적용하여 성능 향상
* 03f3f03f869a1d725067dc78002d642d564b1d54: 인기 검색어 상위 10개 조회용 유스케이스(`LoadPopularKeywordUseCase`) 및 서비스(`PopularKeywordService`) 구현
* 077c4bea8acf9b820ec1e1e61c24814a9d669da2: 인기 검색어 조회 API 엔드포인트(`/api/search/popular-keywords`) 추가 및 DTO(`PopularKeywordResponse`) 정의
* 4c4d58e7a6aa21e1bff763a070ad1cedaf4b887e: 검색 서비스에 인기 검색어 집계 호출 추가
* fc19a8891e94d7032fd8ab4da943454da94644e4, 2041b5d74bf9483cc7101729773bbbbbdef0bae9, c82385bb328ac3a7acbc6f31652d08f19c11e28b: 단위 테스트 및 통합 테스트 작성으로 기능 검증

## 테스트 체크리스트

* [x] 인기 검색어 집계 로직 단위 테스트 통과
* [x] 인기 검색어 조회 유스케이스 및 서비스 단위 테스트 통과
* [x] 인기 검색어 조회 API 통합 테스트 통과
* [x] 검색 시 인기 검색어 카운트가 정상 증가하는지 확인

## 테스트 결과 요약

* 인기 검색어 집계 및 조회에 관련된 모든 테스트가 성공적으로 통과되었습니다.
* API 호출 시 인기 검색어 상위 10개를 정확히 JSON 형태로 반환함을 확인했습니다.
* 비동기 처리된 키워드 카운트 증가가 정상적으로 동작함을 검증했습니다.
