### PR TITLE
feat: 도서 검색 서비스용 Dockerfile 및 docker-compose 설정 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM openjdk:21-slim AS builder
+
+# 컨테이너 내부 작업 디렉토리 설정
+WORKDIR /app
+
+# Gradle Wrapper, Gradle 설정 디렉토리 복사
+COPY gradlew .
+COPY gradle ./gradle/
+
+# Gradle 빌드 설정 파일 복사
+COPY build.gradle .
+COPY settings.gradle .
+
+# 애플리케이션 소스 코드 복사
+COPY src ./src/
+
+# Gradle Wrapper 실행 권한 부여 (리눅스 실행 가능하게)
+RUN chmod +x ./gradlew
+
+# 애플리케이션 빌드 (테스트 제외)
+RUN ./gradlew bootJar -x test --stacktrace
+
+# 빌드된 JAR 파일을 app.jar로 복사 (경로는 빌드 결과물 위치에 맞게)
+RUN cp build/libs/book-search-service-0.0.1-SNAPSHOT.jar app.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.8'
+
+services:
+  mysql:
+    image: mysql:latest
+    container_name: mysql-container
+    environment:
+      MYSQL_ROOT_PASSWORD: root1234!!
+      MYSQL_DATABASE: book_db
+    ports:
+      - "3306:3306"
+    networks:
+      - book-service-network
+
+  book-search:
+    image: book-search-image
+    container_name: book-search-container
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mysql
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql-container:3306/book_db
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: root1234!!
+    networks:
+      - book-service-network
+
+networks:
+  book-service-network:
+    driver: bridge


### PR DESCRIPTION
## 개요
도서 검색 서비스의 컨테이너화 작업을 위해 Dockerfile과 docker-compose 설정을 추가합니다.

## 주요 변경사항
- 99861ae858de028df1bcdf58ee7390ea53cbb555
  - OpenJDK 21 slim 기반 Dockerfile 작성 및 빌드 자동화 설정
  - MySQL과 도서 검색 서비스 컨테이너를 함께 실행할 수 있도록 docker-compose 구성
  - Spring Boot 애플리케이션과 MySQL 간의 네트워크 설정 및 환경 변수 추가

## 테스트 체크리스트
- Docker 이미지 빌드 및 컨테이너 실행 확인
- 도서 검색 서비스가 MySQL 데이터베이스와 정상적으로 연동되는지 테스트
- 서비스가 포트 8080에서 정상 동작하는지 확인
