### PR TITLE
fix: InvalidException에 대한 핸들러를 추가하여 BAD_REQUEST 상태를 반환하도록 수정

### DIFF
--- a/src/main/java/org/example/booksearchservice/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/booksearchservice/common/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.example.booksearchservice.common.exception.ErrorCode.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Slf4j
@@ -20,12 +21,21 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = NotFoundException.class)
-    public ResponseEntity<String> handleBookException(NotFoundException e) {
+    public ResponseEntity<String> handleNotFoundException(NotFoundException e) {
         ErrorCode errorCode = e.getErrorCode();
         String message = errorCode.getMessage();
         log.warn("[NotFoundException] Status: [{}], Message: [{}]", NOT_FOUND, message);
         return new ResponseEntity<>(message, NOT_FOUND);
     }
+
+    @ExceptionHandler(value = InvalidException.class)
+    public ResponseEntity<String> handleInvalidException(InvalidException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        String message = errorCode.getMessage();
+        log.warn("[InvalidException] Status: [{}], Message: [{}]", BAD_REQUEST, message);
+        return new ResponseEntity<>(message, BAD_REQUEST);
+    }
+
 
     @ExceptionHandler(value = MethodArgumentNotValidException.class)
     public ResponseEntity<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {


### PR DESCRIPTION
### **개요**

`GlobalExceptionHandler`에서 `InvalidException`을 처리하도록 추가하여, 해당 예외 발생 시 500 에러가 아닌 400 Bad Request가 반환되도록 수정했습니다.

### **주요 변경사항**

* b8f4880c6fbffa10e8c8285fec6b74285e491678:  `GlobalExceptionHandler`에 `InvalidException` 핸들러 추가 및 400 Bad Request 반환 처리

### **테스트**

* InvalidException 발생 시 400 응답으로 정상 처리 확인