### PR TITLE
refactor: 검색 키워드 유효성 검증 및 쿼리 파싱 로직 개선

### DIFF
--- a/src/main/java/org/example/booksearchservice/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/booksearchservice/common/exception/ErrorCode.java
@@ -18,7 +18,10 @@ public enum ErrorCode {
 
     // Search
     UNSUPPORTED_OPERATOR("지원하지 않는 검색 연산자입니다."),
-    INVALID_KEYWORD_COUNT("두 개의 키워드가 필요합니다.");
+    INVALID_KEYWORD_COUNT("두 개의 키워드가 필요합니다."),
+    KEYWORD_REQUIRED("검색어는 반드시 입력해야합니다."),
+    INVALID_KEYWORD_LENGTH("검색 키워드는 2자 이상 50자 이하여야 합니다."),
+    INVALID_KEYWORD_PATTERN("허용되지 않은 문자가 포함되어 있습니다.");
 
     private final String message;
 }

--- a/src/main/java/org/example/booksearchservice/search/application/service/SearchQueryParser.java
+++ b/src/main/java/org/example/booksearchservice/search/application/service/SearchQueryParser.java
@@ -14,10 +14,7 @@ public class SearchQueryParser {
         SearchOperator operator = SearchOperator.fromQuery(query);
         List<String> keywords = parseKeywords(query, operator);
 
-        return SearchQuery.builder()
-                .keywords(keywords)
-                .operator(operator)
-                .build();
+        return SearchQuery.of(keywords, operator);
     }
 
     private List<String> parseKeywords(String query, SearchOperator operator) {

--- a/src/main/java/org/example/booksearchservice/search/application/service/SearchService.java
+++ b/src/main/java/org/example/booksearchservice/search/application/service/SearchService.java
@@ -7,6 +7,7 @@ import org.example.booksearchservice.search.application.dto.SearchResponse;
 import org.example.booksearchservice.search.application.usecase.OperatorSearchUseCase;
 import org.example.booksearchservice.search.application.usecase.KeywordSearchUseCase;
 import org.example.booksearchservice.search.application.usecase.UpdatePopularKeywordUseCase;
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.example.booksearchservice.search.domain.SearchOperator;
 import org.example.booksearchservice.search.domain.SearchQuery;
 import org.springframework.data.domain.Pageable;
@@ -27,8 +28,9 @@ public class SearchService {
     private final UpdatePopularKeywordUseCase updatePopularKeywordUseCase;
 
     public SearchResponse searchBooksByKeyword(String keyword, Pageable pageable) {
-        BookPageResponse bookPageResponse = keywordSearchUseCase.execute(keyword, pageable);
-        updatePopularKeywordUseCase.execute(keyword);
+        SearchKeyword searchKeyword = SearchKeyword.of(keyword);
+        BookPageResponse bookPageResponse = keywordSearchUseCase.execute(searchKeyword, pageable);
+        updatePopularKeywordUseCase.execute(searchKeyword);
         return buildSearchResponse(keyword, bookPageResponse, NONE);
     }
 

--- a/src/main/java/org/example/booksearchservice/search/application/usecase/KeywordSearchUseCase.java
+++ b/src/main/java/org/example/booksearchservice/search/application/usecase/KeywordSearchUseCase.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.search.application.port.BookInternalPort;
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,8 +17,8 @@ public class KeywordSearchUseCase {
     private final BookInternalPort bookInternalPort;
 
     @Transactional(readOnly = true)
-    public BookPageResponse execute(String keyword, Pageable pageable) {
+    public BookPageResponse execute(SearchKeyword keyword, Pageable pageable) {
         log.info("Executing keyword search for keyword: [{}]", keyword);
-        return bookInternalPort.findBooksByKeyword(keyword, pageable);
+        return bookInternalPort.findBooksByKeyword(keyword.getValue(), pageable);
     }
 }

--- a/src/main/java/org/example/booksearchservice/search/application/usecase/NotSearchUseCase.java
+++ b/src/main/java/org/example/booksearchservice/search/application/usecase/NotSearchUseCase.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.search.application.port.BookInternalPort;
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,9 +18,9 @@ public class NotSearchUseCase implements OperatorSearchUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public BookPageResponse execute(String firstKeyword, String secondKeyword, Pageable pageable) {
+    public BookPageResponse execute(SearchKeyword firstKeyword, SearchKeyword secondKeyword, Pageable pageable) {
         log.info("Executing NOT search with firstKeyword: [{}], excluding secondKeyword: [{}]",
-                firstKeyword, secondKeyword);
-        return bookInternalPort.findBooksByKeywordExcluding(firstKeyword, secondKeyword, pageable);
+                firstKeyword.getValue(), secondKeyword.getValue());
+        return bookInternalPort.findBooksByKeywordExcluding(firstKeyword.getValue(), secondKeyword.getValue(), pageable);
     }
 }

--- a/src/main/java/org/example/booksearchservice/search/application/usecase/OperatorSearchUseCase.java
+++ b/src/main/java/org/example/booksearchservice/search/application/usecase/OperatorSearchUseCase.java
@@ -1,9 +1,10 @@
 package org.example.booksearchservice.search.application.usecase;
 
 import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.springframework.data.domain.Pageable;
 
 public interface OperatorSearchUseCase {
-    BookPageResponse execute(String firstKeyword, String secondKeyword, Pageable pageable);
+    BookPageResponse execute(SearchKeyword firstKeyword, SearchKeyword secondKeyword, Pageable pageable);
 }
 

--- a/src/main/java/org/example/booksearchservice/search/application/usecase/OrSearchUseCase.java
+++ b/src/main/java/org/example/booksearchservice/search/application/usecase/OrSearchUseCase.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.search.application.port.BookInternalPort;
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,9 +18,9 @@ public class OrSearchUseCase implements OperatorSearchUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public BookPageResponse execute(String firstKeyword, String secondKeyword, Pageable pageable) {
+    public BookPageResponse execute(SearchKeyword firstKeyword, SearchKeyword secondKeyword, Pageable pageable) {
         log.info("Executing OR search with firstKeyword: [{}], secondKeyword: [{}]",
                 firstKeyword, secondKeyword);
-        return bookInternalPort.findBooksByAnyKeyword(firstKeyword, secondKeyword, pageable);
+        return bookInternalPort.findBooksByAnyKeyword(firstKeyword.getValue(), secondKeyword.getValue(), pageable);
     }
 }

--- a/src/main/java/org/example/booksearchservice/search/application/usecase/UpdatePopularKeywordUseCase.java
+++ b/src/main/java/org/example/booksearchservice/search/application/usecase/UpdatePopularKeywordUseCase.java
@@ -3,6 +3,7 @@ package org.example.booksearchservice.search.application.usecase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.booksearchservice.search.application.port.UpdatePopularKeywordPort;
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -14,8 +15,8 @@ public class UpdatePopularKeywordUseCase {
     private final UpdatePopularKeywordPort updatePopularKeywordPort;
 
     @Async
-    public void execute(String keyword) {
-        updatePopularKeywordPort.incrementCount(keyword);
+    public void execute(SearchKeyword keyword) {
+        updatePopularKeywordPort.incrementCount(keyword.getValue());
         log.info("Successfully incremented popular keyword: [{}]", keyword);
     }
 }

--- a/src/main/java/org/example/booksearchservice/search/domain/SearchKeyword.java
+++ b/src/main/java/org/example/booksearchservice/search/domain/SearchKeyword.java
@@ -1,0 +1,70 @@
+package org.example.booksearchservice.search.domain;
+
+import lombok.Value;
+import org.example.booksearchservice.search.exception.InvalidSearchQueryException;
+
+import java.util.regex.Pattern;
+
+import static org.example.booksearchservice.common.exception.ErrorCode.*;
+
+@Value
+public class SearchKeyword {
+    private static final int MIN_LENGTH = 2;
+    private static final int MAX_LENGTH = 50;
+
+    private static final Pattern VALID_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣\\s]+$");
+
+    private static final String WHITESPACE_REGEX = "\\s+";
+    private static final String SINGLE_SPACE = " ";
+
+    String value;
+
+    private SearchKeyword(String value) {
+        this.value = normalize(value);
+    }
+
+    /**
+     * 주어진 문자열로부터 SearchKeyword 객체를 생성한다.
+     * 유효성 검사를 수행하며, 조건에 맞지 않으면 예외를 던진다.
+     */
+    public static SearchKeyword of(String value) {
+        if (value == null) throw new InvalidSearchQueryException(KEYWORD_REQUIRED);
+
+        String trimmed = value.trim();
+
+        if (!isValidLength(trimmed)) throw new InvalidSearchQueryException(INVALID_KEYWORD_LENGTH);
+        if (!matchesPattern(trimmed)) throw new InvalidSearchQueryException(INVALID_KEYWORD_PATTERN);
+
+        return new SearchKeyword(trimmed);
+    }
+
+    /**
+     * 키워드의 길이가 허용된 범위 내에 있는지 확인한다.
+     * 최소 길이: 2자, 최대 길이: 50자
+     */
+    private static boolean isValidLength(String value) {
+        int length = value.length();
+        return length >= MIN_LENGTH && length <= MAX_LENGTH;
+    }
+
+    /**
+     * 키워드가 허용된 문자만 포함하는지 확인한다.
+     * 허용 문자: 영문자(a-z, A-Z), 숫자(0-9), 한글, 공백
+     * 금지 문자: 특수문자, 구두점, 기호
+     */
+    private static boolean matchesPattern(String value) {
+        return VALID_PATTERN.matcher(value).matches();
+    }
+
+    /**
+     * 키워드를 정규화한다.
+     * 1. 소문자로 변환
+     * 2. 연속된 공백을 하나의 공백으로 치환
+     * 3. 앞뒤 공백 제거
+     */
+    private static String normalize(String value) {
+        return value.toLowerCase()
+                .replaceAll(WHITESPACE_REGEX, SINGLE_SPACE)
+                .trim();
+    }
+}

--- a/src/main/java/org/example/booksearchservice/search/domain/SearchQuery.java
+++ b/src/main/java/org/example/booksearchservice/search/domain/SearchQuery.java
@@ -1,27 +1,39 @@
 package org.example.booksearchservice.search.domain;
 
-import lombok.Builder;
-import lombok.Getter;
+import lombok.Value;
 import org.example.booksearchservice.search.exception.InvalidSearchQueryException;
 
 import java.util.List;
 
 import static org.example.booksearchservice.common.exception.ErrorCode.INVALID_KEYWORD_COUNT;
 
-@Getter
+@Value
 public class SearchQuery {
 
-    private final String firstKeyword;
-    private final String secondKeyword;
-    private final SearchOperator operator;
+    private static final int REQUIRED_KEYWORD_COUNT = 2;
 
-    @Builder
-    private SearchQuery(List<String> keywords, SearchOperator operator) {
-        if(keywords.size() != 2) {
+    SearchKeyword firstKeyword;
+    SearchKeyword secondKeyword;
+    SearchOperator operator;
+
+    private SearchQuery(SearchKeyword firstKeyword, SearchKeyword secondKeyword, SearchOperator operator) {
+        this.firstKeyword = firstKeyword;
+        this.secondKeyword = secondKeyword;
+        this.operator = operator;
+    }
+
+    /**
+     * 주어진 키워드 리스트와 연산자로부터 SearchQuery 객체를 생성한다.
+     * 키워드 리스트는 반드시 2개의 키워드를 포함해야 하며, 그렇지 않으면 예외를 던진다.
+     */
+    public static SearchQuery of(List<String> keywords, SearchOperator operator) {
+        if (keywords == null || keywords.size() != REQUIRED_KEYWORD_COUNT) {
             throw new InvalidSearchQueryException(INVALID_KEYWORD_COUNT);
         }
-        this.firstKeyword = keywords.getFirst();
-        this.secondKeyword = keywords.getLast();
-        this.operator = operator;
+
+        SearchKeyword first = SearchKeyword.of(keywords.getFirst());
+        SearchKeyword second = SearchKeyword.of(keywords.getLast());
+
+        return new SearchQuery(first, second, operator);
     }
 }

--- a/src/test/java/org/example/booksearchservice/search/domain/SearchKeywordTest.java
+++ b/src/test/java/org/example/booksearchservice/search/domain/SearchKeywordTest.java
@@ -1,0 +1,60 @@
+package org.example.booksearchservice.search.domain;
+
+import org.example.booksearchservice.search.exception.InvalidSearchQueryException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.example.booksearchservice.common.exception.ErrorCode.*;
+
+@DisplayName("SearchKeyword 도메인 테스트")
+class SearchKeywordTest {
+
+    @Test
+    @DisplayName("[SUCCESS] 유효한 키워드로 SearchKeyword 인스턴스를 생성한다")
+    void validKeyword_createsInstance() {
+        SearchKeyword keyword = SearchKeyword.of("Java Spring");
+        assertThat(keyword.getValue()).isEqualTo("java spring");
+    }
+
+    @Test
+    @DisplayName("[ERROR] null 키워드는 예외를 발생시킨다")
+    void nullKeyword_throwsException() {
+        assertThatThrownBy(() -> SearchKeyword.of(null))
+                .isInstanceOf(InvalidSearchQueryException.class)
+                .hasMessageContaining(KEYWORD_REQUIRED.getMessage());
+    }
+
+    @Test
+    @DisplayName("[ERROR] 빈 문자열 키워드는 예외를 발생시킨다")
+    void tooShortKeyword_throwsException() {
+        assertThatThrownBy(() -> SearchKeyword.of("a"))
+                .isInstanceOf(InvalidSearchQueryException.class)
+                .hasMessageContaining(INVALID_KEYWORD_LENGTH.getMessage());
+    }
+
+    @Test
+    @DisplayName("[ERROR] 50자를 초과하는 키워드는 예외를 발생시킨다")
+    void tooLongKeyword_throwsException() {
+        String longKeyword = "a".repeat(51);
+        assertThatThrownBy(() -> SearchKeyword.of(longKeyword))
+                .isInstanceOf(InvalidSearchQueryException.class)
+                .hasMessageContaining(INVALID_KEYWORD_LENGTH.getMessage());
+    }
+
+    @Test
+    @DisplayName("[ERROR] 특수 문자가 포함된 키워드는 예외를 발생시킨다")
+    void invalidPatternKeyword_throwsException() {
+        assertThatThrownBy(() -> SearchKeyword.of("java!@#"))
+                .isInstanceOf(InvalidSearchQueryException.class)
+                .hasMessageContaining(INVALID_KEYWORD_PATTERN.getMessage());
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 여러 공백이 포함된 키워드는 단일 공백으로 정규화된다")
+    void keywordWithMultipleSpaces_normalizesToSingleSpace() {
+        SearchKeyword keyword = SearchKeyword.of("  Java   Spring   Boot  ");
+        assertThat(keyword.getValue()).isEqualTo("java spring boot");
+    }
+}

--- a/src/test/java/org/example/booksearchservice/search/domain/SearchOperatorTest.java
+++ b/src/test/java/org/example/booksearchservice/search/domain/SearchOperatorTest.java
@@ -1,0 +1,43 @@
+package org.example.booksearchservice.search.domain;
+
+import org.example.booksearchservice.search.exception.InvalidSearchQueryException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.example.booksearchservice.common.exception.ErrorCode.UNSUPPORTED_OPERATOR;
+
+@DisplayName("SearchOperator 도메인 테스트")
+class SearchOperatorTest {
+
+    @Test
+    @DisplayName("[SUCCESS] fromQuery 메서드는 쿼리 문자열에 포함된 연산자를 올바르게 판별한다")
+    void fromQuery_withOrSymbol_returnsOrOperator() {
+        SearchOperator op = SearchOperator.fromQuery("java|spring");
+        assertThat(op).isEqualTo(SearchOperator.OR);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] fromQuery 메서드는 쿼리 문자열에 포함된 연산자를 올바르게 판별한다")
+    void fromQuery_withNotSymbol_returnsNotOperator() {
+        SearchOperator op = SearchOperator.fromQuery("java-spring");
+        assertThat(op).isEqualTo(SearchOperator.NOT);
+    }
+
+    @Test
+    @DisplayName("[ERROR] fromQuery 메서드는 지원되지 않는 연산자가 포함된 경우 예외를 던진다")
+    void fromQuery_withNoOperator_throwsException() {
+        assertThatThrownBy(() -> SearchOperator.fromQuery("javaspring"))
+                .isInstanceOf(InvalidSearchQueryException.class)
+                .hasMessageContaining(UNSUPPORTED_OPERATOR.getMessage());
+    }
+
+    @Test
+    @DisplayName("[ERROR] fromQuery 메서드는 지원되지 않는 연산자가 포함된 경우 예외를 던진다")
+    void fromQuery_withUnsupportedOperator_throwsException() {
+        assertThatThrownBy(() -> SearchOperator.fromQuery("java&spring"))
+                .isInstanceOf(InvalidSearchQueryException.class)
+                .hasMessageContaining(UNSUPPORTED_OPERATOR.getMessage());
+    }
+}

--- a/src/test/java/org/example/booksearchservice/search/domain/SearchQueryTest.java
+++ b/src/test/java/org/example/booksearchservice/search/domain/SearchQueryTest.java
@@ -1,0 +1,48 @@
+package org.example.booksearchservice.search.domain;
+
+import org.example.booksearchservice.search.exception.InvalidSearchQueryException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.example.booksearchservice.common.exception.ErrorCode.INVALID_KEYWORD_COUNT;
+
+@DisplayName("SearchQuery 도메인 테스트")
+class SearchQueryTest {
+
+    @Test
+    @DisplayName("[SUCCESS] 유효한 키워드와 연산자로 SearchQuery 인스턴스를 생성한다")
+    void validKeywords_createsInstance() {
+        SearchQuery query = SearchQuery.of(List.of("Java", "Spring"), SearchOperator.OR);
+        assertThat(query.getFirstKeyword().getValue()).isEqualTo("java");
+        assertThat(query.getSecondKeyword().getValue()).isEqualTo("spring");
+        assertThat(query.getOperator()).isEqualTo(SearchOperator.OR);
+    }
+
+    @Test
+    @DisplayName("[ERROR] null 키워드 리스트는 예외를 발생시킨다")
+    void nullKeywords_throwsException() {
+        assertThatThrownBy(() -> SearchQuery.of(null, SearchOperator.OR))
+                .isInstanceOf(InvalidSearchQueryException.class)
+                .hasMessageContaining(INVALID_KEYWORD_COUNT.getMessage());
+    }
+
+    @Test
+    @DisplayName("[ERROR] 2개 미만의 키워드는 예외를 발생시킨다")
+    void lessThanTwoKeywords_throwsException() {
+        assertThatThrownBy(() -> SearchQuery.of(List.of("Java"), SearchOperator.OR))
+                .isInstanceOf(InvalidSearchQueryException.class)
+                .hasMessageContaining(INVALID_KEYWORD_COUNT.getMessage());
+    }
+
+    @Test
+    @DisplayName("[ERROR] 2개 초과의 키워드는 예외를 발생시킨다")
+    void moreThanTwoKeywords_throwsException() {
+        assertThatThrownBy(() -> SearchQuery.of(List.of("Java", "Spring", "Boot"), SearchOperator.OR))
+                .isInstanceOf(InvalidSearchQueryException.class)
+                .hasMessageContaining(INVALID_KEYWORD_COUNT.getMessage());
+    }
+}

--- a/src/test/java/org/example/booksearchservice/search/service/SearchServiceTest.java
+++ b/src/test/java/org/example/booksearchservice/search/service/SearchServiceTest.java
@@ -9,6 +9,7 @@ import org.example.booksearchservice.search.application.service.SearchService;
 import org.example.booksearchservice.search.application.usecase.KeywordSearchUseCase;
 import org.example.booksearchservice.search.application.usecase.OperatorSearchUseCase;
 import org.example.booksearchservice.search.application.usecase.UpdatePopularKeywordUseCase;
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.example.booksearchservice.search.domain.SearchOperator;
 import org.example.booksearchservice.search.domain.SearchQuery;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,7 +68,7 @@ public class SearchServiceTest {
         Page<Book> bookPage = new PageImpl<>(books, pageable, books.size());
         BookPageResponse bookPageResponse = BookPageResponse.of(bookPage);
 
-        when(keywordSearchUseCase.execute(keyword, pageable)).thenReturn(bookPageResponse);
+        when(keywordSearchUseCase.execute(SearchKeyword.of(keyword), pageable)).thenReturn(bookPageResponse);
 
         // when
         SearchResponse response = searchService.searchBooksByKeyword(keyword, pageable);
@@ -91,17 +92,14 @@ public class SearchServiceTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         SearchOperator operator = SearchOperator.OR;
-        SearchQuery searchQuery = SearchQuery.builder()
-                .keywords(List.of("java", "spring"))
-                .operator(operator)
-                .build();
+        SearchQuery searchQuery = SearchQuery.of(List.of("java", "spring"), operator);
 
         List<Book> books = List.of(createBook());
         Page<Book> bookPage = new PageImpl<>(books, pageable, books.size());
         BookPageResponse bookPageResponse = BookPageResponse.of(bookPage);
 
         when(searchQueryParser.parse(query)).thenReturn(searchQuery);
-        when(orOperatorSearchUseCase.execute("java", "spring", pageable))
+        when(orOperatorSearchUseCase.execute(searchQuery.getFirstKeyword(), searchQuery.getSecondKeyword(), pageable))
                 .thenReturn(bookPageResponse);
 
         // when

--- a/src/test/java/org/example/booksearchservice/search/usecase/KeywordSearchUseCaseTest.java
+++ b/src/test/java/org/example/booksearchservice/search/usecase/KeywordSearchUseCaseTest.java
@@ -4,6 +4,7 @@ import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.mock.FakeBookInternalAdapter;
 import org.example.booksearchservice.search.application.port.BookInternalPort;
 import org.example.booksearchservice.search.application.usecase.KeywordSearchUseCase;
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,7 @@ public class KeywordSearchUseCaseTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        BookPageResponse response = keywordSearchUseCase.execute(keyword, pageable);
+        BookPageResponse response = keywordSearchUseCase.execute(SearchKeyword.of(keyword), pageable);
 
         // then
         assertThat(

--- a/src/test/java/org/example/booksearchservice/search/usecase/NotSearchUseCaseTest.java
+++ b/src/test/java/org/example/booksearchservice/search/usecase/NotSearchUseCaseTest.java
@@ -4,6 +4,7 @@ import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.mock.FakeBookInternalAdapter;
 import org.example.booksearchservice.search.application.port.BookInternalPort;
 import org.example.booksearchservice.search.application.usecase.NotSearchUseCase;
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,7 @@ class NotSearchUseCaseTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        BookPageResponse response = notSearchUseCase.execute(firstKeyword, secondKeyword, pageable);
+        BookPageResponse response = notSearchUseCase.execute(SearchKeyword.of(firstKeyword), SearchKeyword.of(secondKeyword), pageable);
 
         // then
         assertThat(response.pageInfo().totalElements()).isEqualTo(1);

--- a/src/test/java/org/example/booksearchservice/search/usecase/OrSearchUseCaseTest.java
+++ b/src/test/java/org/example/booksearchservice/search/usecase/OrSearchUseCaseTest.java
@@ -4,6 +4,7 @@ import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.mock.FakeBookInternalAdapter;
 import org.example.booksearchservice.search.application.port.BookInternalPort;
 import org.example.booksearchservice.search.application.usecase.OrSearchUseCase;
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,7 @@ class OrSearchUseCaseTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        BookPageResponse response = orSearchUseCase.execute(firstKeyword, secondKeyword, pageable);
+        BookPageResponse response = orSearchUseCase.execute(SearchKeyword.of(firstKeyword), SearchKeyword.of(secondKeyword), pageable);
 
         // then
         assertThat(response.pageInfo().totalElements()).isEqualTo(3);

--- a/src/test/java/org/example/booksearchservice/search/usecase/UpdatePopularKeywordUseCaseTest.java
+++ b/src/test/java/org/example/booksearchservice/search/usecase/UpdatePopularKeywordUseCaseTest.java
@@ -1,6 +1,7 @@
 package org.example.booksearchservice.search.usecase;
 
 import org.example.booksearchservice.search.application.usecase.UpdatePopularKeywordUseCase;
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.example.booksearchservice.search.infrastructure.cache.InMemoryPopularKeywordAdapter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +27,7 @@ class UpdatePopularKeywordUseCaseTest {
     void execute_incrementsKeywordCount() {
         String keyword = "java";
 
-        useCase.execute(keyword);
+        useCase.execute(SearchKeyword.of(keyword));
 
         List<String> topKeywords = inMemoryAdapter.findTop10Keywords();
         assertThat(topKeywords.size()).isEqualTo(1);


### PR DESCRIPTION
## 📝 개요

검색 서비스 전반에 걸쳐 검색 키워드와 관련된 유효성 검증 로직을 강화하고, `SearchQuery`와 `SearchKeyword` 중심으로 쿼리 파싱 구조를 리팩토링했습니다.

## 🔑 주요 변경사항

* **SearchKeyword 도메인 추가**
  * 최소/최대 길이(2\~50자) 및 허용 문자(영문, 숫자, 한글, 공백) 검증
  * 키워드 정규화 로직(소문자 변환, 연속 공백 단일화) 적용
* **SearchQuery 리팩토링**
  * 문자열 대신 `SearchKeyword`를 활용하도록 개선
  * 키워드 개수(2개) 검증 로직 추가
* **ErrorCode 확장**
  * `KEYWORD_REQUIRED`, `INVALID_KEYWORD_LENGTH`, `INVALID_KEYWORD_PATTERN` 추가
* **서비스/유스케이스 수정**
  * `KeywordSearchUseCase`, `NotSearchUseCase`, `OrSearchUseCase`, `UpdatePopularKeywordUseCase`에서 `SearchKeyword` 사용
  * `SearchQueryParser` 로직 단순화
* **테스트 추가/수정**
  * `SearchKeywordTest`, `SearchQueryTest`, `SearchOperatorTest` 신규 작성
  * 기존 `SearchServiceTest`, UseCase 테스트(Search/Not/Or/UpdatePopularKeyword) 수정

## ✅ 테스트 체크리스트

* [x] SearchKeyword 유효성 검증 및 정규화 테스트 통과
* [x] SearchQuery.of 키워드 개수 검증 정상 동작
* [x] SearchOperator fromQuery 예외 처리 검증
* [x] SearchService 및 각 OperatorSearchUseCase 정상 동작 확인
* [x] UpdatePopularKeywordUseCase 정상 동작 및 로그 출력 확인

## 📊 테스트 결과 요약

* 모든 단위 테스트 통과 
