### PR TITLE
refactor: 검색 키워드 객체 기반으로 검색 로직 리팩토링

### DIFF
--- a/src/main/java/org/example/booksearchservice/search/application/port/BookInternalPort.java
+++ b/src/main/java/org/example/booksearchservice/search/application/port/BookInternalPort.java
@@ -1,10 +1,11 @@
 package org.example.booksearchservice.search.application.port;
 
 import org.example.booksearchservice.book.application.dto.BookPageResponse;
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.springframework.data.domain.Pageable;
 
 public interface BookInternalPort {
-    BookPageResponse findBooksByKeyword(String keyword, Pageable pageable);
-    BookPageResponse findBooksByAnyKeyword(String firstKeyword, String secondKeyword, Pageable pageable);
-    BookPageResponse findBooksByKeywordExcluding(String firstKeyword, String secondKeyword, Pageable pageable);
+    BookPageResponse findBooksByKeyword(SearchKeyword keyword, Pageable pageable);
+    BookPageResponse findBooksByAnyKeyword(SearchKeyword firstKeyword, SearchKeyword secondKeyword, Pageable pageable);
+    BookPageResponse findBooksByKeywordExcluding(SearchKeyword firstKeyword, SearchKeyword secondKeyword, Pageable pageable);
 }

--- a/src/main/java/org/example/booksearchservice/search/application/port/UpdatePopularKeywordPort.java
+++ b/src/main/java/org/example/booksearchservice/search/application/port/UpdatePopularKeywordPort.java
@@ -1,5 +1,7 @@
 package org.example.booksearchservice.search.application.port;
 
+import org.example.booksearchservice.search.domain.SearchKeyword;
+
 public interface UpdatePopularKeywordPort {
-    void incrementCount(String keyword);
+    void incrementCount(SearchKeyword keyword);
 }

--- a/src/main/java/org/example/booksearchservice/search/application/service/SearchQueryParser.java
+++ b/src/main/java/org/example/booksearchservice/search/application/service/SearchQueryParser.java
@@ -1,26 +1,38 @@
 package org.example.booksearchservice.search.application.service;
 
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.example.booksearchservice.search.domain.SearchOperator;
 import org.example.booksearchservice.search.domain.SearchQuery;
+import org.example.booksearchservice.search.exception.InvalidSearchQueryException;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.example.booksearchservice.common.exception.ErrorCode.INVALID_KEYWORD_COUNT;
 
 @Component
 public class SearchQueryParser {
 
+    private static final int REQUIRED_KEYWORD_COUNT = 2;
+
     public SearchQuery parse(String query) {
         SearchOperator operator = SearchOperator.fromQuery(query);
-        List<String> keywords = parseKeywords(query, operator);
+        List<SearchKeyword> keywords = parseAndCreateKeywords(query, operator);
 
-        return SearchQuery.of(keywords, operator);
+        if (keywords.size() != REQUIRED_KEYWORD_COUNT) {
+            throw new InvalidSearchQueryException(INVALID_KEYWORD_COUNT);
+        }
+
+        return SearchQuery.of(keywords.getFirst(), keywords.getLast(), operator);
     }
 
-    private List<String> parseKeywords(String query, SearchOperator operator) {
+    private List<SearchKeyword> parseAndCreateKeywords(String query, SearchOperator operator) {
         return Arrays.stream(query.split(operator.getSplitRegex()))
                 .map(String::trim)
                 .filter(keyword -> !keyword.isEmpty())
-                .toList();
+                .map(SearchKeyword::of)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/example/booksearchservice/search/application/service/SearchService.java
+++ b/src/main/java/org/example/booksearchservice/search/application/service/SearchService.java
@@ -4,12 +4,14 @@ import lombok.RequiredArgsConstructor;
 import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.search.application.dto.SearchMetaData;
 import org.example.booksearchservice.search.application.dto.SearchResponse;
-import org.example.booksearchservice.search.application.usecase.OperatorSearchUseCase;
 import org.example.booksearchservice.search.application.usecase.KeywordSearchUseCase;
+import org.example.booksearchservice.search.application.usecase.OperatorSearchUseCase;
 import org.example.booksearchservice.search.application.usecase.UpdatePopularKeywordUseCase;
 import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.example.booksearchservice.search.domain.SearchOperator;
 import org.example.booksearchservice.search.domain.SearchQuery;
+import org.example.booksearchservice.search.presentation.dto.ComplexSearchRequest;
+import org.example.booksearchservice.search.presentation.dto.SimpleSearchRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -27,15 +29,24 @@ public class SearchService {
 
     private final UpdatePopularKeywordUseCase updatePopularKeywordUseCase;
 
-    public SearchResponse searchBooksByKeyword(String keyword, Pageable pageable) {
-        SearchKeyword searchKeyword = SearchKeyword.of(keyword);
+    public SearchResponse searchBooksByKeyword(SimpleSearchRequest request, Pageable pageable) {
+        String keywordValue = request.keyword();
+        SearchKeyword searchKeyword = SearchKeyword.of(keywordValue);
+
         BookPageResponse bookPageResponse = keywordSearchUseCase.execute(searchKeyword, pageable);
         updatePopularKeywordUseCase.execute(searchKeyword);
-        return buildSearchResponse(keyword, bookPageResponse, NONE);
+
+        return SearchResponse.of(
+                keywordValue,
+                bookPageResponse.pageInfo(),
+                bookPageResponse.books(),
+                SearchMetaData.ofDefaultExecutionTime(NONE)
+        );
     }
 
-    public SearchResponse searchBooksByComplexQuery(String query, Pageable pageable) {
-        SearchQuery searchQuery = searchQueryParser.parse(query);
+    public SearchResponse searchBooksByComplexQuery(ComplexSearchRequest request, Pageable pageable) {
+        String rawQuery = request.query();
+        SearchQuery searchQuery = searchQueryParser.parse(rawQuery);
         SearchOperator searchOperator = searchQuery.getOperator();
 
         OperatorSearchUseCase operatorSearchUseCase = operatorSearchUseCaseMap.get(searchOperator.name());
@@ -47,12 +58,8 @@ public class SearchService {
 
         updatePopularKeywordUseCase.execute(searchQuery.getFirstKeyword());
 
-        return buildSearchResponse(query, bookPageResponse, searchOperator);
-    }
-
-    private SearchResponse buildSearchResponse(String query, BookPageResponse bookPageResponse, SearchOperator searchOperator) {
         return SearchResponse.of(
-                query,
+                rawQuery,
                 bookPageResponse.pageInfo(),
                 bookPageResponse.books(),
                 SearchMetaData.ofDefaultExecutionTime(searchOperator)

--- a/src/main/java/org/example/booksearchservice/search/application/usecase/KeywordSearchUseCase.java
+++ b/src/main/java/org/example/booksearchservice/search/application/usecase/KeywordSearchUseCase.java
@@ -18,7 +18,7 @@ public class KeywordSearchUseCase {
 
     @Transactional(readOnly = true)
     public BookPageResponse execute(SearchKeyword keyword, Pageable pageable) {
-        log.info("Executing keyword search for keyword: [{}]", keyword);
-        return bookInternalPort.findBooksByKeyword(keyword.getValue(), pageable);
+        log.info("Executing keyword search for keyword: [{}]", keyword.getValue());
+        return bookInternalPort.findBooksByKeyword(keyword, pageable);
     }
 }

--- a/src/main/java/org/example/booksearchservice/search/application/usecase/NotSearchUseCase.java
+++ b/src/main/java/org/example/booksearchservice/search/application/usecase/NotSearchUseCase.java
@@ -21,6 +21,6 @@ public class NotSearchUseCase implements OperatorSearchUseCase {
     public BookPageResponse execute(SearchKeyword firstKeyword, SearchKeyword secondKeyword, Pageable pageable) {
         log.info("Executing NOT search with firstKeyword: [{}], excluding secondKeyword: [{}]",
                 firstKeyword.getValue(), secondKeyword.getValue());
-        return bookInternalPort.findBooksByKeywordExcluding(firstKeyword.getValue(), secondKeyword.getValue(), pageable);
+        return bookInternalPort.findBooksByKeywordExcluding(firstKeyword, secondKeyword, pageable);
     }
 }

--- a/src/main/java/org/example/booksearchservice/search/application/usecase/OrSearchUseCase.java
+++ b/src/main/java/org/example/booksearchservice/search/application/usecase/OrSearchUseCase.java
@@ -20,7 +20,7 @@ public class OrSearchUseCase implements OperatorSearchUseCase {
     @Transactional(readOnly = true)
     public BookPageResponse execute(SearchKeyword firstKeyword, SearchKeyword secondKeyword, Pageable pageable) {
         log.info("Executing OR search with firstKeyword: [{}], secondKeyword: [{}]",
-                firstKeyword, secondKeyword);
-        return bookInternalPort.findBooksByAnyKeyword(firstKeyword.getValue(), secondKeyword.getValue(), pageable);
+                firstKeyword.getValue(), secondKeyword.getValue());
+        return bookInternalPort.findBooksByAnyKeyword(firstKeyword, secondKeyword, pageable);
     }
 }

--- a/src/main/java/org/example/booksearchservice/search/application/usecase/UpdatePopularKeywordUseCase.java
+++ b/src/main/java/org/example/booksearchservice/search/application/usecase/UpdatePopularKeywordUseCase.java
@@ -16,7 +16,7 @@ public class UpdatePopularKeywordUseCase {
 
     @Async
     public void execute(SearchKeyword keyword) {
-        updatePopularKeywordPort.incrementCount(keyword.getValue());
-        log.info("Successfully incremented popular keyword: [{}]", keyword);
+        updatePopularKeywordPort.incrementCount(keyword);
+        log.info("Successfully incremented popular keyword: [{}]", keyword.getValue());
     }
 }

--- a/src/main/java/org/example/booksearchservice/search/domain/SearchKeyword.java
+++ b/src/main/java/org/example/booksearchservice/search/domain/SearchKeyword.java
@@ -9,62 +9,50 @@ import static org.example.booksearchservice.common.exception.ErrorCode.*;
 
 @Value
 public class SearchKeyword {
+
     private static final int MIN_LENGTH = 2;
     private static final int MAX_LENGTH = 50;
-
     private static final Pattern VALID_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣\\s]+$");
-
     private static final String WHITESPACE_REGEX = "\\s+";
     private static final String SINGLE_SPACE = " ";
 
     String value;
 
-    private SearchKeyword(String value) {
-        this.value = normalize(value);
+    private SearchKeyword(String keyword) {
+        if (keyword == null) {
+            throw new InvalidSearchQueryException(KEYWORD_REQUIRED);
+        }
+
+        String normalizedKeyword = normalize(keyword);
+        validate(normalizedKeyword);
+        this.value = normalizedKeyword;
     }
 
-    /**
-     * 주어진 문자열로부터 SearchKeyword 객체를 생성한다.
-     * 유효성 검사를 수행하며, 조건에 맞지 않으면 예외를 던진다.
-     */
     public static SearchKeyword of(String value) {
-        if (value == null) throw new InvalidSearchQueryException(KEYWORD_REQUIRED);
-
-        String trimmed = value.trim();
-
-        if (!isValidLength(trimmed)) throw new InvalidSearchQueryException(INVALID_KEYWORD_LENGTH);
-        if (!matchesPattern(trimmed)) throw new InvalidSearchQueryException(INVALID_KEYWORD_PATTERN);
-
-        return new SearchKeyword(trimmed);
+        return new SearchKeyword(value);
     }
 
-    /**
-     * 키워드의 길이가 허용된 범위 내에 있는지 확인한다.
-     * 최소 길이: 2자, 최대 길이: 50자
-     */
-    private static boolean isValidLength(String value) {
-        int length = value.length();
+    private static boolean isValidLength(String keyword) {
+        int length = keyword.length();
         return length >= MIN_LENGTH && length <= MAX_LENGTH;
     }
 
-    /**
-     * 키워드가 허용된 문자만 포함하는지 확인한다.
-     * 허용 문자: 영문자(a-z, A-Z), 숫자(0-9), 한글, 공백
-     * 금지 문자: 특수문자, 구두점, 기호
-     */
-    private static boolean matchesPattern(String value) {
-        return VALID_PATTERN.matcher(value).matches();
+    private static boolean matchesPattern(String keyword) {
+        return VALID_PATTERN.matcher(keyword).matches();
     }
 
-    /**
-     * 키워드를 정규화한다.
-     * 1. 소문자로 변환
-     * 2. 연속된 공백을 하나의 공백으로 치환
-     * 3. 앞뒤 공백 제거
-     */
-    private static String normalize(String value) {
-        return value.toLowerCase()
+    private static String normalize(String keyword) {
+        return keyword.trim()
                 .replaceAll(WHITESPACE_REGEX, SINGLE_SPACE)
-                .trim();
+                .toLowerCase();
+    }
+
+    private void validate(String keyword) {
+        if (!isValidLength(keyword)) {
+            throw new InvalidSearchQueryException(INVALID_KEYWORD_LENGTH);
+        }
+        if (!matchesPattern(keyword)) {
+            throw new InvalidSearchQueryException(INVALID_KEYWORD_PATTERN);
+        }
     }
 }

--- a/src/main/java/org/example/booksearchservice/search/domain/SearchQuery.java
+++ b/src/main/java/org/example/booksearchservice/search/domain/SearchQuery.java
@@ -3,37 +3,29 @@ package org.example.booksearchservice.search.domain;
 import lombok.Value;
 import org.example.booksearchservice.search.exception.InvalidSearchQueryException;
 
-import java.util.List;
-
 import static org.example.booksearchservice.common.exception.ErrorCode.INVALID_KEYWORD_COUNT;
 
 @Value
 public class SearchQuery {
 
-    private static final int REQUIRED_KEYWORD_COUNT = 2;
-
     SearchKeyword firstKeyword;
     SearchKeyword secondKeyword;
     SearchOperator operator;
 
-    private SearchQuery(SearchKeyword firstKeyword, SearchKeyword secondKeyword, SearchOperator operator) {
-        this.firstKeyword = firstKeyword;
-        this.secondKeyword = secondKeyword;
+    private SearchQuery(SearchKeyword first, SearchKeyword second, SearchOperator operator) {
+        this.firstKeyword = first;
+        this.secondKeyword = second;
         this.operator = operator;
     }
 
     /**
-     * 주어진 키워드 리스트와 연산자로부터 SearchQuery 객체를 생성한다.
-     * 키워드 리스트는 반드시 2개의 키워드를 포함해야 하며, 그렇지 않으면 예외를 던진다.
+     * 주어진 두 개의 SearchKeyword 객체와 연산자로부터 SearchQuery 객체를 생성한다.
+     * 주어진 키워드는 반드시 null이 아니어야 하며, 그렇지 않으면 예외를 던진다.
      */
-    public static SearchQuery of(List<String> keywords, SearchOperator operator) {
-        if (keywords == null || keywords.size() != REQUIRED_KEYWORD_COUNT) {
+    public static SearchQuery of(SearchKeyword first, SearchKeyword second, SearchOperator operator) {
+        if (first == null || second == null) {
             throw new InvalidSearchQueryException(INVALID_KEYWORD_COUNT);
         }
-
-        SearchKeyword first = SearchKeyword.of(keywords.getFirst());
-        SearchKeyword second = SearchKeyword.of(keywords.getLast());
-
         return new SearchQuery(first, second, operator);
     }
 }

--- a/src/main/java/org/example/booksearchservice/search/infrastructure/cache/InMemoryPopularKeywordAdapter.java
+++ b/src/main/java/org/example/booksearchservice/search/infrastructure/cache/InMemoryPopularKeywordAdapter.java
@@ -2,6 +2,7 @@ package org.example.booksearchservice.search.infrastructure.cache;
 
 import org.example.booksearchservice.search.application.port.LoadPopularKeywordPort;
 import org.example.booksearchservice.search.application.port.UpdatePopularKeywordPort;
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -25,8 +26,8 @@ public class InMemoryPopularKeywordAdapter implements LoadPopularKeywordPort, Up
     }
 
     @Override
-    public void incrementCount(String keyword) {
-        keywordCountMap.merge(keyword, 1, Integer::sum);
+    public void incrementCount(SearchKeyword keyword) {
+        keywordCountMap.merge(keyword.getValue(), 1, Integer::sum);
     }
 }
 

--- a/src/main/java/org/example/booksearchservice/search/infrastructure/internal/BookInternalAdapter.java
+++ b/src/main/java/org/example/booksearchservice/search/infrastructure/internal/BookInternalAdapter.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.book.application.service.BookQueryService;
 import org.example.booksearchservice.search.application.port.BookInternalPort;
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
@@ -14,17 +15,17 @@ public class BookInternalAdapter implements BookInternalPort {
     private final BookQueryService bookQueryService;
 
     @Override
-    public BookPageResponse findBooksByKeyword(String keyword, Pageable pageable) {
-        return bookQueryService.findBooksByKeyword(keyword, pageable);
+    public BookPageResponse findBooksByKeyword(SearchKeyword keyword, Pageable pageable) {
+        return bookQueryService.findBooksByKeyword(keyword.getValue(), pageable);
     }
 
     @Override
-    public BookPageResponse findBooksByAnyKeyword(String firstKeyword, String secondKeyword, Pageable pageable) {
-        return bookQueryService.findBooksByAnyKeyword(firstKeyword, secondKeyword, pageable);
+    public BookPageResponse findBooksByAnyKeyword(SearchKeyword firstKeyword, SearchKeyword secondKeyword, Pageable pageable) {
+        return bookQueryService.findBooksByAnyKeyword(firstKeyword.getValue(), secondKeyword.getValue(), pageable);
     }
 
     @Override
-    public BookPageResponse findBooksByKeywordExcluding(String firstKeyword, String secondKeyword, Pageable pageable) {
-        return bookQueryService.findBooksByKeywordExcluding(firstKeyword, secondKeyword, pageable);
+    public BookPageResponse findBooksByKeywordExcluding(SearchKeyword firstKeyword, SearchKeyword secondKeyword, Pageable pageable) {
+        return bookQueryService.findBooksByKeywordExcluding(firstKeyword.getValue(), secondKeyword.getValue(), pageable);
     }
 }

--- a/src/main/java/org/example/booksearchservice/search/presentation/web/SearchController.java
+++ b/src/main/java/org/example/booksearchservice/search/presentation/web/SearchController.java
@@ -28,7 +28,7 @@ public class SearchController {
             @RequestParam(defaultValue = DEFAULT_SIZE) int size) {
 
         Pageable pageable = PageRequest.of(page, size);
-        SearchResponse response = searchService.searchBooksByKeyword(request.keyword(), pageable);
+        SearchResponse response = searchService.searchBooksByKeyword(request, pageable);
         return ResponseEntity.ok(response);
     }
 
@@ -39,7 +39,7 @@ public class SearchController {
             @RequestParam(defaultValue = DEFAULT_SIZE) int size) {
 
         Pageable pageable = PageRequest.of(page, size);
-        SearchResponse response = searchService.searchBooksByComplexQuery(request.query(), pageable);
+        SearchResponse response = searchService.searchBooksByComplexQuery(request, pageable);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/test/java/org/example/booksearchservice/mock/FakeBookInternalAdapter.java
+++ b/src/test/java/org/example/booksearchservice/mock/FakeBookInternalAdapter.java
@@ -3,6 +3,7 @@ package org.example.booksearchservice.mock;
 import org.example.booksearchservice.book.application.dto.BookPageResponse;
 import org.example.booksearchservice.book.domain.Book;
 import org.example.booksearchservice.search.application.port.BookInternalPort;
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -14,25 +15,25 @@ import static org.example.booksearchservice.fixture.BookFixture.createBooks;
 public class FakeBookInternalAdapter implements BookInternalPort {
 
     @Override
-    public BookPageResponse findBooksByKeyword(String keyword, Pageable pageable) {
-        List<Book> filteredBooks = filterBooksByKeywords(List.of(keyword));
+    public BookPageResponse findBooksByKeyword(SearchKeyword keyword, Pageable pageable) {
+        List<Book> filteredBooks = filterBooksByKeywords(List.of(keyword.getValue()));
         Page<Book> bookPage = new PageImpl<>(filteredBooks, pageable, filteredBooks.size());
         return BookPageResponse.of(bookPage);
     }
 
     @Override
-    public BookPageResponse findBooksByAnyKeyword(String firstKeyword, String secondKeyword, Pageable pageable) {
-        List<Book> filteredBooks = filterBooksByKeywords(List.of(firstKeyword, secondKeyword));
+    public BookPageResponse findBooksByAnyKeyword(SearchKeyword firstKeyword, SearchKeyword secondKeyword, Pageable pageable) {
+        List<Book> filteredBooks = filterBooksByKeywords(List.of(firstKeyword.getValue(), secondKeyword.getValue()));
         Page<Book> bookPage = new PageImpl<>(filteredBooks, pageable, filteredBooks.size());
         return BookPageResponse.of(bookPage);
     }
 
     @Override
-    public BookPageResponse findBooksByKeywordExcluding(String firstKeyword, String secondKeyword, Pageable pageable) {
+    public BookPageResponse findBooksByKeywordExcluding(SearchKeyword firstKeyword, SearchKeyword secondKeyword, Pageable pageable) {
         List<Book> allBooks = createBooks(5);
         List<Book> filteredBooks = allBooks.stream()
-                .filter(book -> containsKeyword(book, firstKeyword))
-                .filter(book -> !containsKeyword(book, secondKeyword))
+                .filter(book -> containsKeyword(book, firstKeyword.getValue()))
+                .filter(book -> !containsKeyword(book, secondKeyword.getValue()))
                 .toList();
 
         Page<Book> bookPage = new PageImpl<>(filteredBooks, pageable, filteredBooks.size());

--- a/src/test/java/org/example/booksearchservice/search/domain/SearchQueryTest.java
+++ b/src/test/java/org/example/booksearchservice/search/domain/SearchQueryTest.java
@@ -4,8 +4,6 @@ import org.example.booksearchservice.search.exception.InvalidSearchQueryExceptio
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.example.booksearchservice.common.exception.ErrorCode.INVALID_KEYWORD_COUNT;
@@ -16,7 +14,7 @@ class SearchQueryTest {
     @Test
     @DisplayName("[SUCCESS] 유효한 키워드와 연산자로 SearchQuery 인스턴스를 생성한다")
     void validKeywords_createsInstance() {
-        SearchQuery query = SearchQuery.of(List.of("Java", "Spring"), SearchOperator.OR);
+        SearchQuery query = SearchQuery.of(SearchKeyword.of("Java"), SearchKeyword.of("Spring"), SearchOperator.OR);
         assertThat(query.getFirstKeyword().getValue()).isEqualTo("java");
         assertThat(query.getSecondKeyword().getValue()).isEqualTo("spring");
         assertThat(query.getOperator()).isEqualTo(SearchOperator.OR);
@@ -25,7 +23,7 @@ class SearchQueryTest {
     @Test
     @DisplayName("[ERROR] null 키워드 리스트는 예외를 발생시킨다")
     void nullKeywords_throwsException() {
-        assertThatThrownBy(() -> SearchQuery.of(null, SearchOperator.OR))
+        assertThatThrownBy(() -> SearchQuery.of(null, null, SearchOperator.OR))
                 .isInstanceOf(InvalidSearchQueryException.class)
                 .hasMessageContaining(INVALID_KEYWORD_COUNT.getMessage());
     }
@@ -33,15 +31,7 @@ class SearchQueryTest {
     @Test
     @DisplayName("[ERROR] 2개 미만의 키워드는 예외를 발생시킨다")
     void lessThanTwoKeywords_throwsException() {
-        assertThatThrownBy(() -> SearchQuery.of(List.of("Java"), SearchOperator.OR))
-                .isInstanceOf(InvalidSearchQueryException.class)
-                .hasMessageContaining(INVALID_KEYWORD_COUNT.getMessage());
-    }
-
-    @Test
-    @DisplayName("[ERROR] 2개 초과의 키워드는 예외를 발생시킨다")
-    void moreThanTwoKeywords_throwsException() {
-        assertThatThrownBy(() -> SearchQuery.of(List.of("Java", "Spring", "Boot"), SearchOperator.OR))
+        assertThatThrownBy(() -> SearchQuery.of(SearchKeyword.of("Java"), null, SearchOperator.OR))
                 .isInstanceOf(InvalidSearchQueryException.class)
                 .hasMessageContaining(INVALID_KEYWORD_COUNT.getMessage());
     }

--- a/src/test/java/org/example/booksearchservice/search/infrastructure/InMemoryPopularKeywordAdapterTest.java
+++ b/src/test/java/org/example/booksearchservice/search/infrastructure/InMemoryPopularKeywordAdapterTest.java
@@ -1,5 +1,6 @@
 package org.example.booksearchservice.search.infrastructure;
 
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.example.booksearchservice.search.infrastructure.cache.InMemoryPopularKeywordAdapter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,8 +22,8 @@ class InMemoryPopularKeywordAdapterTest {
     @Test
     @DisplayName("키워드 카운트가 정상적으로 증가하는지 테스트")
     void incrementCount_increasesCountCorrectly() {
-        inMemoryPopularKeywordAdapter.incrementCount("java");
-        inMemoryPopularKeywordAdapter.incrementCount("java");
+        inMemoryPopularKeywordAdapter.incrementCount(SearchKeyword.of("java"));
+        inMemoryPopularKeywordAdapter.incrementCount(SearchKeyword.of("java"));
 
         List<String> topKeywords = inMemoryPopularKeywordAdapter.findTop10Keywords();
 
@@ -36,7 +37,7 @@ class InMemoryPopularKeywordAdapterTest {
         for (int i = 0; i < 20; i++) {
             String keyword = "keyword" + i;
             for (int j = 0; j < i; j++) {
-                inMemoryPopularKeywordAdapter.incrementCount(keyword);
+                inMemoryPopularKeywordAdapter.incrementCount(SearchKeyword.of(keyword));
             }
         }
 

--- a/src/test/java/org/example/booksearchservice/search/presentation/PopularKeywordControllerTest.java
+++ b/src/test/java/org/example/booksearchservice/search/presentation/PopularKeywordControllerTest.java
@@ -1,5 +1,6 @@
 package org.example.booksearchservice.search.presentation;
 
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.example.booksearchservice.search.infrastructure.cache.InMemoryPopularKeywordAdapter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,7 +33,7 @@ public class PopularKeywordControllerTest {
         for (int i = 1; i <= 15; i++) {
             String keyword = "keyword" + i;
             for (int j = 0; j < i; j++) {  // i만큼 count 증가
-                popularKeywordAdapter.incrementCount(keyword);
+                popularKeywordAdapter.incrementCount(SearchKeyword.of(keyword));
             }
         }
     }

--- a/src/test/java/org/example/booksearchservice/search/service/SearchServiceTest.java
+++ b/src/test/java/org/example/booksearchservice/search/service/SearchServiceTest.java
@@ -12,6 +12,8 @@ import org.example.booksearchservice.search.application.usecase.UpdatePopularKey
 import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.example.booksearchservice.search.domain.SearchOperator;
 import org.example.booksearchservice.search.domain.SearchQuery;
+import org.example.booksearchservice.search.presentation.dto.ComplexSearchRequest;
+import org.example.booksearchservice.search.presentation.dto.SimpleSearchRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -71,7 +73,7 @@ public class SearchServiceTest {
         when(keywordSearchUseCase.execute(SearchKeyword.of(keyword), pageable)).thenReturn(bookPageResponse);
 
         // when
-        SearchResponse response = searchService.searchBooksByKeyword(keyword, pageable);
+        SearchResponse response = searchService.searchBooksByKeyword(new SimpleSearchRequest(keyword), pageable);
 
         // then
         AssertionsForClassTypes.assertThat(
@@ -92,7 +94,7 @@ public class SearchServiceTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         SearchOperator operator = SearchOperator.OR;
-        SearchQuery searchQuery = SearchQuery.of(List.of("java", "spring"), operator);
+        SearchQuery searchQuery = SearchQuery.of(SearchKeyword.of("java"), SearchKeyword.of("spring"), operator);
 
         List<Book> books = List.of(createBook());
         Page<Book> bookPage = new PageImpl<>(books, pageable, books.size());
@@ -103,7 +105,7 @@ public class SearchServiceTest {
                 .thenReturn(bookPageResponse);
 
         // when
-        SearchResponse response = searchService.searchBooksByComplexQuery(query, pageable);
+        SearchResponse response = searchService.searchBooksByComplexQuery(new ComplexSearchRequest(query), pageable);
 
         // then
         assertThat(response.books()).hasSize(1);

--- a/src/test/java/org/example/booksearchservice/search/usecase/LoadPopularKeywordUseCaseTest.java
+++ b/src/test/java/org/example/booksearchservice/search/usecase/LoadPopularKeywordUseCaseTest.java
@@ -1,6 +1,7 @@
 package org.example.booksearchservice.search.usecase;
 
 import org.example.booksearchservice.search.application.usecase.LoadPopularKeywordUseCase;
+import org.example.booksearchservice.search.domain.SearchKeyword;
 import org.example.booksearchservice.search.infrastructure.cache.InMemoryPopularKeywordAdapter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +22,7 @@ public class LoadPopularKeywordUseCaseTest {
         for (int i = 1; i <= 15; i++) {
             String keyword = "keyword" + i;
             for (int j = 0; j < i; j++) {
-                popularKeywordAdapter.incrementCount(keyword);
+                popularKeywordAdapter.incrementCount(SearchKeyword.of(keyword));
             }
         }
     }


### PR DESCRIPTION
## 📝 개요
검색 키워드를 단순 문자열(String) 대신 `SearchKeyword` VO(Value Object)로 일관성 있게 사용하도록 리팩토링했습니다.  
유효성 검증과 정규화를 객체 내부에서 책임지도록 하여 타입 안정성과 응집도를 강화했습니다.

## 🔑 주요 변경사항
- `BookInternalPort`, `UpdatePopularKeywordPort` 등 포트 인터페이스에서 `String` → `SearchKeyword`로 변경
- `SearchQueryParser`에서 키워드 파싱 시 `SearchKeyword` 객체 생성 로직 적용
- `SearchService`에서 단순/복합 검색 요청 시 DTO(`SimpleSearchRequest`, `ComplexSearchRequest`) 기반으로 처리하도록 개선
- `SearchQuery` 팩토리 메서드 수정: 리스트 입력 대신 `SearchKeyword` 2개를 직접 전달받도록 변경
- `UpdatePopularKeywordUseCase` 및 캐시 어댑터에서 `SearchKeyword` 객체 처리 방식 적용
- 테스트 코드 전반 수정 (`SearchQueryTest`, `SearchServiceTest`, `InMemoryPopularKeywordAdapterTest` 등)

## ✅ 테스트 체크리스트
- [x] 단일 키워드 검색 시 정상 동작
- [x] OR / NOT 연산자 기반 복합 검색 정상 동작
- [x] 유효하지 않은 키워드 입력 시 예외 발생
- [x] 인기 검색어 카운트 증가 로직 정상 동작
- [x] Mock/Fake 어댑터 테스트 정상 통과

## 📊 테스트 결과 요약
- 전체 단위 테스트 및 통합 테스트 통과 
- 키워드 유효성 검증, 정규화, 캐싱 로직 정상 동작 확인
